### PR TITLE
Change deprecated `textsize` to `fontsize`

### DIFF
--- a/src/HOHQMesh.jl
+++ b/src/HOHQMesh.jl
@@ -10,6 +10,9 @@ function __init__()
   # Enable features that depend on the availability of the Makie package
   @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" begin
     using .Makie
+    if isdefined(Makie, :to_textsize)
+      @warn "You seem to be using an older version of Makie (< v0.19). Some plotting functions may not work."
+    end
     include("Viz/VizProject.jl")
     include("Viz/VizMesh.jl")
     # Make the actual plotting routines available

--- a/src/Viz/VizProject.jl
+++ b/src/Viz/VizProject.jl
@@ -171,7 +171,7 @@ function plotCurve(plt, points::Matrix{Float64}, legendLabel::String, curveLabel
     #     theta = 0.0
     # end
     pp = (points[np,1],points[np,2])
-    text!(plt[1,1],curveLabel,textsize = 28, position = pp, align = (:center,:center) )
+    text!(plt[1,1],curveLabel, fontsize = 28, position = pp, align = (:center,:center) )
 end
 
 


### PR DESCRIPTION
Newer releases of Makie have [replaced `textsize` everywhere in favor of `fontsize`](https://github.com/MakieOrg/Makie.jl/pull/2387).

Closes #20 