### PR TITLE
Removed deprecated keyword from plotting

### DIFF
--- a/src/Viz/VizProject.jl
+++ b/src/Viz/VizProject.jl
@@ -19,7 +19,7 @@ Contents are overlaid in the order: GRID, MESH, MODEL, REFINEMENTS
 function plotProject!(proj::Project, plotOptions::Int = 0)
 
     if isnothing(proj.plt)
-        proj.plt = Figure(resolution = (1000, 1000))
+        proj.plt = Figure(size = (1000, 1000))
     end
     plt = proj.plt
     ax = plt[1,1] = Axis(plt)
@@ -120,7 +120,7 @@ This version replots the figure with the current options. Legacy.
 """
 function updatePlot!(proj::Project)
     if !isnothing(proj.plt)
-        proj.plt = Figure(resolution = (1000, 1000))
+        proj.plt = Figure(size = (1000, 1000))
         plotOptions = proj.plotOptions
         plotProject!(proj, plotOptions)
     end
@@ -138,7 +138,7 @@ Example: updatePlot!(p, MESH + MODEL)
 """
 function updatePlot!(proj::Project, plotOptions::Int)
     if !isnothing(proj.plt)
-        proj.plt = Figure(resolution = (1000, 1000))
+        proj.plt = Figure(size = (1000, 1000))
         plotProject!(proj, plotOptions)
     end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,4 +5,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AbaqusReader = "0.2.5"
-CairoMakie = "0.6, 0.7, 0.8"
+CairoMakie = "0.11"


### PR DESCRIPTION
The keyword `resolution` has been deprecated in Makie and we now use the new suggested keyword `size` for all the `Figure` creation. Once this is merged I will release a new version.