### PR TITLE
Optional arguments for interactive version of `generate_mesh` function

### DIFF
--- a/docs/src/interactive_overview.md
+++ b/docs/src/interactive_overview.md
@@ -146,7 +146,17 @@ To generate a mesh interactively you
 
 ## Advanced
 
-All objects and information contained in the variable type `Project` are actually dictionaries of type `Dict{String, Any}`.
+The `generate_mesh` function has two optional arguments. The first is the logical `verbose`
+argument. One can pass `verbose=true` to output additional messages and information during
+the meshing process. The second is the integer `subdivision_maximum` argument.
+The default value is `subdivision_maximum=8`, meaning that elements can be up
+to a factor of `2^8` smaller than the existing background grid.
+Note, think before adjusting the `subdivision_maximum` level! It is often the case that
+adjusting the boundary curves, background grid size, adding local refinement regions,
+or some combination of these adjustments removes the need to adjust the subdivision depth.
+
+All objects and information contained in the variable type `Project` are actually dictionaries
+of type `Dict{String, Any}`.
 Since Julia is not an object oriented language, the parameters and other parts of these internal dictionaries
 can be accessed and edited directly by key and value.
 However, if you do that, then certain features like `undo`/`redo` and automatic plot updating **will not work**.

--- a/docs/src/interactive_overview.md
+++ b/docs/src/interactive_overview.md
@@ -146,7 +146,7 @@ To generate a mesh interactively you
 
 ## Advanced
 
-The `generate_mesh` function has two optional arguments. The first is the logical `verbose`
+The `generate_mesh` function has two optional arguments. The first is the Boolean `verbose`
 argument. One can pass `verbose=true` to output additional messages and information during
 the meshing process. The second is the integer `subdivision_maximum` argument.
 The default value is `subdivision_maximum=8`, meaning that elements can be up

--- a/src/HOHQMesh.jl
+++ b/src/HOHQMesh.jl
@@ -180,7 +180,7 @@ This function returns the output to `stdout` of the HOHQMesh binary when generat
 function generate_mesh(control_file;
                        output_directory="out",
                        mesh_filename=nothing, plot_filename=nothing, stats_filename=nothing,
-                       verbose=false, subdivision_maximum=8)
+                       verbose=false, subdivision_maximum::Int=8)
   @assert isfile(control_file) "'$control_file' is not a valid path to an existing file"
 
   # Determine output filenames
@@ -230,11 +230,10 @@ function generate_mesh(control_file;
     flush(tmpio)
 
     # Run HOHQMesh and store output
-    str_subdivision_maximum = string(subdivision_maximum)
     if verbose
-      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $str_subdivision_maximum -verbose -f $tmppath`)
+      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $subdivision_maximum -verbose -f $tmppath`)
     else
-      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $str_subdivision_maximum -f $tmppath`)
+      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $subdivision_maximum -f $tmppath`)
     end
   end
 

--- a/src/HOHQMesh.jl
+++ b/src/HOHQMesh.jl
@@ -168,12 +168,19 @@ control file name. For example, `path/to/ControlFile.control` will result in out
 You can activate verbose output from HOHQMesh that prints additional messages and debugging
 mesh information with the keyword argument `verbose`.
 
+To override the maximum number of allowable subdivisions in the quad tree during meshing
+adjust the value of `subdivision_maximum`. The default value of `subdivision_maximum` is 8,
+meaning that elements can be up to a factor of `2^8` smaller than the background grid.
+Note, think before doing this! It could be adjusting the boundary curves, background grid size,
+adding local refinement regions, or some combination may remove the need to adjust
+the subdivision depth.
+
 This function returns the output to `stdout` of the HOHQMesh binary when generating the mesh.
 """
 function generate_mesh(control_file;
                        output_directory="out",
                        mesh_filename=nothing, plot_filename=nothing, stats_filename=nothing,
-                       verbose=false)
+                       verbose=false, subdivision_maximum=8)
   @assert isfile(control_file) "'$control_file' is not a valid path to an existing file"
 
   # Determine output filenames
@@ -223,10 +230,11 @@ function generate_mesh(control_file;
     flush(tmpio)
 
     # Run HOHQMesh and store output
+    str_subdivision_maximum = string(subdivision_maximum)
     if verbose
-      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -verbose -f $tmppath`)
+      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $str_subdivision_maximum -verbose -f $tmppath`)
     else
-      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -f $tmppath`)
+      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $str_subdivision_maximum -f $tmppath`)
     end
   end
 

--- a/src/Mesh/Meshing.jl
+++ b/src/Mesh/Meshing.jl
@@ -23,7 +23,7 @@ the subdivision depth.
 
 This function returns the output to `stdout` of the HOHQMesh binary when generating the mesh.
 """
-function generate_mesh(proj::Project; verbose=false, subdivision_maximum=8)
+function generate_mesh(proj::Project; verbose=false, subdivision_maximum::Int=8)
 #
 #   Check to be sure background grid has been created (everything else is defaults)
 #

--- a/src/Mesh/Meshing.jl
+++ b/src/Mesh/Meshing.jl
@@ -1,6 +1,6 @@
 
 """
-    generate_mesh(proj::Project; verbose::Bool, subdivision_maximum::Integer)
+    generate_mesh(proj::Project; verbose=false, subdivision_maximum=8)
 
 Generate a mesh from the information stored in a `Project` created using the
 interactive mesh functionality. First a check is made
@@ -40,8 +40,8 @@ function generate_mesh(proj::Project; verbose=false, subdivision_maximum=8)
 
     saveProject(proj)
     fileName       = joinpath(proj.projectDirectory,proj.name)*".control"
-    mesherOutput   = generate_mesh(fileName, output_directory = proj.projectDirectory,
-                                   verbose=verbose, subdivision_maximum=subdivision_maximum)
+    mesherOutput   = generate_mesh(fileName; output_directory = proj.projectDirectory,
+                                   verbose, subdivision_maximum)
     println(mesherOutput)
     postNotificationWithName(proj,"MESH_WAS_GENERATED_NOTIFICATION",(nothing,))
     return nothing

--- a/src/Mesh/Meshing.jl
+++ b/src/Mesh/Meshing.jl
@@ -1,6 +1,6 @@
 
 """
-    generate_mesh(proj::Project)
+    generate_mesh(proj::Project; verbose::Bool, subdivision_maximum::Integer)
 
 Generate a mesh from the information stored in a `Project` created using the
 interactive mesh functionality. First a check is made
@@ -11,9 +11,19 @@ and use it to call the wrapper function that interfaces with HOHQMesh. The resul
 will be saved to `proj.projectDirectory`. Also, if there is an active plot of the mesh project it
 will update to display the generated mesh.
 
+With the optional argument `verbose` one can activate verbose output from HOHQMesh
+that prints additional messages and debugging mesh information.
+
+To override the maximum number of allowable subdivisions in the quad tree during meshing
+adjust the value of `subdivision_maximum`. The default value of `subdivision_maximum` is 8,
+meaning that elements can be up to a factor of `2^8` smaller than the background grid.
+Note, think before doing this! It could be adjusting the boundary curves, background grid size,
+adding local refinement regions, or some combination may remove the need to adjust
+the subdivision depth.
+
 This function returns the output to `stdout` of the HOHQMesh binary when generating the mesh.
 """
-function generate_mesh(proj::Project)
+function generate_mesh(proj::Project; verbose=false, subdivision_maximum=8)
 #
 #   Check to be sure background grid has been created (everything else is defaults)
 #
@@ -30,7 +40,8 @@ function generate_mesh(proj::Project)
 
     saveProject(proj)
     fileName       = joinpath(proj.projectDirectory,proj.name)*".control"
-    mesherOutput   = generate_mesh(fileName, output_directory = proj.projectDirectory)
+    mesherOutput   = generate_mesh(fileName, output_directory = proj.projectDirectory,
+                                   verbose=verbose, subdivision_maximum=subdivision_maximum)
     println(mesherOutput)
     postNotificationWithName(proj,"MESH_WAS_GENERATED_NOTIFICATION",(nothing,))
     return nothing

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -59,7 +59,7 @@ using CairoMakie
     @test_nowarn plotProject!(p_visu, MODEL+GRID)
 
     # Create the mesh which contains a plotting update for ISM
-    @test_nowarn generate_mesh(p_visu)
+    @test_nowarn generate_mesh(p_visu, verbose=true)
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)


### PR DESCRIPTION
This gives users the possibility to pass the `verbose` output argument from the interactive tool. Also, a new optional input `subdivision_maximum` allows a user to override the default amount of quadtree subdivisions in HOHQMesh. In the Fortran code this is the `-sLimit` flag. The docs are also updated to briefly explain these optional arguments in the "Advanced" part of the overview, because these flags are likely only used by developers. 