### PR TITLE
Add reference for spring smoothing

### DIFF
--- a/docs/src/interactive-api.md
+++ b/docs/src/interactive-api.md
@@ -112,7 +112,8 @@ type to `LinearAndCrossbarSpring`, and number of iterations = 25.
 These are generally good enough for most purposes.
 The most likely parameter to change is the number of iterations.
 Further details on the smoothing strategy and how it works are available
-[in the documentation](https://trixi-framework.github.io/HOHQMesh/the-control-input/#the-smoother).
+[in the documentation](https://trixi-framework.github.io/HOHQMesh/the-control-input/#the-smoother)
+and in [Minoli2011](https://www.sciencedirect.com/science/article/pii/S0021999110006534?via%3Dihub).
 
 To change the defaults, the smoother parameters can be set/enquired with the functions
 ```


### PR DESCRIPTION
There is already the PR https://github.com/trixi-framework/HOHQMesh/pull/98 to add the spring smoothing reference to HOHQMesh, but I think it's helpful to have it here in case someone is looking for the original source.