### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.6'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -62,7 +62,7 @@ using CairoMakie
     @test_nowarn generate_mesh(p_visu, verbose=true)
 
     # Add a delay to ensure that the Windows system has released the file handles
-    sleep(5.0) # arbitrarily pick 5 seconds
+    sleep(2.0) # arbitrarily pick 2 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)
@@ -96,7 +96,7 @@ using CairoMakie
     @test_nowarn generate_mesh(p_visu)
 
     # Add a delay to ensure that the Windows system has released the file handles
-    sleep(5.0) # arbitrarily pick 5 seconds
+    sleep(2.0) # arbitrarily pick 2 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -61,8 +61,12 @@ using CairoMakie
     # Create the mesh which contains a plotting update for ISM
     @test_nowarn generate_mesh(p_visu, verbose=true)
 
-    # Add a delay to ensure that the Windows system has released the file handles
-    sleep(2.0) # arbitrarily pick 2 seconds
+    # Explicitly call the garbage collector to remove any temporaries
+    # before an attempt to delete any files
+    GC.gc()
+
+    # # Add a delay to ensure that the Windows system has released the file handles
+    # sleep(2.0) # arbitrarily pick 2 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)
@@ -95,8 +99,12 @@ using CairoMakie
     # Create the mesh which contains a plotting update for ISM-V2
     @test_nowarn generate_mesh(p_visu)
 
+    # Explicitly call the garbage collector to remove any temporaries
+    # before an attempt to delete any files
+    GC.gc()
+
     # Add a delay to ensure that the Windows system has released the file handles
-    sleep(2.0) # arbitrarily pick 2 seconds
+    # sleep(2.0) # arbitrarily pick 2 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -62,7 +62,7 @@ using CairoMakie
     @test_nowarn generate_mesh(p_visu, verbose=true)
 
     # Add a delay to ensure that the Windows system has released the file handles
-    sleep(2.0) # arbitrarily pick 2 seconds
+    sleep(5.0) # arbitrarily pick 5 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)
@@ -96,7 +96,7 @@ using CairoMakie
     @test_nowarn generate_mesh(p_visu)
 
     # Add a delay to ensure that the Windows system has released the file handles
-    sleep(2.0) # arbitrarily pick 2 seconds
+    sleep(5.0) # arbitrarily pick 5 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -62,11 +62,10 @@ using CairoMakie
     @test_nowarn generate_mesh(p_visu, verbose=true)
 
     # Explicitly call the garbage collector to remove any temporaries
-    # before an attempt to delete any files
+    # before an attempt to delete any files. Helps avoid an error of type
+    #  `IOError: unlink("some_file"): resource busy or locked (EBUSY)`
+    # on Windows CI runners
     GC.gc()
-
-    # # Add a delay to ensure that the Windows system has released the file handles
-    # sleep(2.0) # arbitrarily pick 2 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)
@@ -100,11 +99,10 @@ using CairoMakie
     @test_nowarn generate_mesh(p_visu)
 
     # Explicitly call the garbage collector to remove any temporaries
-    # before an attempt to delete any files
+    # before an attempt to delete any files. Helps avoid an error of type
+    #  `IOError: unlink("some_file"): resource busy or locked (EBUSY)`
+    # on Windows CI runners
     GC.gc()
-
-    # Add a delay to ensure that the Windows system has released the file handles
-    # sleep(2.0) # arbitrarily pick 2 seconds
 
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)


### PR DESCRIPTION
~~Windows seems to take sometime to close an IOStream and a file. This bumps up the amount of idle time to avoid erroneous errors that occur with back-to-back `generate_mesh` and `remove_mesh!` calls on Windows systems.~~

Windows sometimes does not close the IOStream and release a file. With the advice from [here](https://discourse.julialang.org/t/find-what-has-locked-held-a-file/23278) adding an explicit call to the garbage collector `GC.gc()` before one attempts to delete the file fixes the CI issue.