### PR TITLE
Restrict HOHQMesh_jll compatibility version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 HOHQMeshMakieExt = "Makie"
 
 [compat]
-HOHQMesh_jll = "1.0"
+HOHQMesh_jll = "=1.5.1"
 Makie = "0.20, 0.24"
 Requires = "1.1.3"
 julia = "1.6"


### PR DESCRIPTION
We also use the same approach in P4est.jl. The issue is that we do not run real CI tests when releasing a new version of jll packages. Thus, we chose to fix the jll version in the Julia wrapper to get a chance to test new versions of jll packages before "really" releasing them.

CompatHelper should notify us about updates of HOHQMESH_jll. Whenever this is the case, we should update the compat bound to a new `=X.Y.Z` version.