### PR TITLE
Update developer instructions for releasing a new version

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -45,11 +45,18 @@ mode [julia-emacs](https://github.com/JuliaEditorSupport/julia-emacs).
 - Check whether everything is okay, tests pass etc.
 - Set the new version number in `Project.toml` according to the Julian version of semver.
   Commit and push.
-- Comment `@JuliaRegistrator register` on the commit setting the version number.
+- Comment `@JuliaRegistrator register` on the commit setting the version number. If the release includes breaking changes, it is also required to provide release notes by commenting:
+  ```
+  @JuliaRegistrator register
+
+  Release notes:
+
+  The breaking changes are documented in the NEWS.md file in the repository and in the changelog in the documentation, see https://trixi-framework.github.io/HOHQMesh.jl/stable/changelog/
+  ```
 - `JuliaRegistrator` will create a PR with the new version in the General registry.
   Wait for it to be merged.
-- Increment the version number in `Project.toml` again with suffix `-pre`. For example,
-  if you have released version `v0.2.0`, use `v0.2.1-pre` as new version number.
+- Increment the version number in `Project.toml` again with suffix `-DEV`. For example,
+  if you have released version `v0.2.0`, use `v0.2.1-DEV` as new version number.
 
 
 


### PR DESCRIPTION
The old instructions said to set development versions to `-pre` instead of `-DEV`