### PR TITLE
Update Project.toml with generic bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 HOHQMeshMakieExt = "Makie"
 
 [compat]
-HOHQMesh_jll = "=1.5.1"
+HOHQMesh_jll = "1.0"
 Makie = "0.20, 0.24"
 Requires = "1.1.3"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 HOHQMeshMakieExt = "Makie"
 
 [compat]
-HOHQMesh_jll = "1.0"
+HOHQMesh_jll = "=1.6.0"
 Makie = "0.20, 0.24"
 Requires = "1.1.3"
 julia = "1.6"


### PR DESCRIPTION
With fixes in the `build_tarballs.jl` for HOHQMesh (https://github.com/JuliaPackaging/Yggdrasil/pull/14360) the latest version `v1.6.0` of HOHQMesh is available for the Julia frontend.

This supplants #102 .