### PR TITLE
Update tutorials

### DIFF
--- a/docs/src/tutorials/create_edit_curves.md
+++ b/docs/src/tutorials/create_edit_curves.md
@@ -113,7 +113,7 @@ the outer boundary and background grid. The resulting plot is given below. The c
 curves is called `"Outer"` and it contains three curve segments `"Line1"`, `"Arc"`, and `"Line2"`
 labeled in the figure by `O.1`, `O.2`, and `O.3`, respectively.
 
-![background_grid](https://user-images.githubusercontent.com/25242486/175062627-a87ed6e1-ce68-4ef4-a178-96b1ccceff0a.png)
+![background_grid](https://github.com/user-attachments/assets/535c120f-6dc1-420a-b8e5-c4810891af21)
 
 ## Edit the outer boundary chain
 
@@ -137,7 +137,7 @@ removeOuterBoundaryCurveWithName!(sandbox_project, "Line2")
 The plot automatically updates and we see that the outer boundary is open and contains
 two segments: `"Line1"` and `"Arc"`.
 
-![outer_removal](https://user-images.githubusercontent.com/25242486/175062663-8a0e3a4f-c444-4302-a35b-7565095ab78a.png)
+![outer_removal](https://github.com/user-attachments/assets/2a15e20c-789e-41ad-b9cb-b9e6d7e105eb)
 
 Next, we create a parametric cubic spline curve from a given set of data points. In order to make a
 closed outer boundary chain the cubic spline must begin at the endpoint of the curve `"Arc"`
@@ -162,7 +162,7 @@ addCurveToOuterBoundary!(sandbox_project, outer_spline)
 The figure updates automatically to display the `"Outer"` boundary chain
 with the new `"Spline"` curve labeled `O.3`.
 
-![outer_spline](https://user-images.githubusercontent.com/25242486/175062706-6d12840c-f5fa-49e6-ad18-d46d643dd3d8.png)
+![outer_spline](https://github.com/user-attachments/assets/a00206a5-0faa-42aa-b00f-d807ad830d3c)
 
 ## Add an inner boundary chain
 
@@ -225,7 +225,7 @@ of the background grid automatically detects that curves have been added to the
 `"Line1"`, `"TopArc"`, `"Line2"`, and `"BottomArc"` labeled in the figure by
 `1.1`, `1.2`, `1.3`, and `1.4`, respectively.
 
-![inner_pill](https://user-images.githubusercontent.com/25242486/175062834-91aae24d-167d-4d0f-8d39-887ab189081b.png)
+![inner_pill](https://github.com/user-attachments/assets/84cece24-15aa-4146-9a1b-0c668dc60717)
 
 ## Generate the mesh
 
@@ -274,7 +274,7 @@ The background grid is *removed* from the visualization when the mesh is generat
     Currently, only the "skeleton" of the mesh is visualized. Thus, the high-order curved boundary information
     is not seen in the plot but this information **is present** in the generated mesh file.
 
-![initial_mesh](https://user-images.githubusercontent.com/25242486/175062901-4f1280ae-9830-4ab3-bee2-76f895b03cbb.png)
+![initial_mesh](https://github.com/user-attachments/assets/72a8b7a8-bbb8-46e8-b336-a64c16e01f2a)
 
 ## Delete the existing mesh
 
@@ -314,7 +314,7 @@ With either removal strategy, the plot automatically updates. We see that the
 inner boundary is open and contains three segments: `"BottomArc"`, `"Line2"`, and `"TopArc"`.
 Note that the index of the remaining curves has changed as shown below.
 
-![inner_removal](https://user-images.githubusercontent.com/25242486/175062997-6f60b3e3-b9eb-4f6b-8062-5b17de0cca2c.png)
+![inner_removal](https://github.com/user-attachments/assets/9412a3ca-8736-49b2-bf50-6af65bb2ef95)
 
 !!! note "Brief note about undo / redo"
     The interactive functionality (globally) carries an operation stack of actions that can be undone
@@ -364,7 +364,7 @@ addCurveToInnerBoundary!(sandbox_project, inner_eqn, "inner")
 ```
 The automatically updated figure now shows:
 
-![inner_open_chain](https://user-images.githubusercontent.com/25242486/175063103-e8eda78c-b0d9-4229-9383-5582845d5f81.png)
+![inner_open_chain](https://github.com/user-attachments/assets/866603cb-51e8-4f7e-a645-054c47aabd8b)
 
 We see from the figure and form of the parametric equations $x(t)$ and $y(t)$
 have that the parametric equation curve starts at the point $(x(0), y(0)) = (2, 3)$
@@ -391,7 +391,7 @@ removeInnerBoundaryCurve!(sandbox_project, "BottomArc", "inner")
 The figure updates to display the `"inner"` curve chain with three segments.
 Note that the inner curve chain indexing has, again, been automatically adjusted.
 
-![inner_remove_arc](https://user-images.githubusercontent.com/25242486/175063146-9475697a-3aa8-42c1-abdb-713343c6b8f7.png)
+![inner_remove_arc](https://github.com/user-attachments/assets/612b1812-5df9-429f-b70f-415fbc33ebdd)
 
 A half-circle arc that joins the points $(-1, 3)$ and $(2, 3)$ has a radius $r=1.5$,
 is centered at $(0.5, 3)$ and has an angle that varies from $-180$ to $0$.
@@ -409,7 +409,7 @@ The updated plot now gives the modified, closed inner curve chain that now conta
 four curve segments `"TopArc"`, `"Line2"`, `"wideBottomArc"`, and `"wiggleLine"` labeled
 in the figure by `1.1`, `1.2`, `1.3`, and `1.4`, respectively.
 
-![inner_modified](https://user-images.githubusercontent.com/25242486/175063184-9c2d1204-cdcd-4a33-88bd-d73e7183b3d6.png)
+![inner_modified](https://github.com/user-attachments/assets/33085a4c-b425-4346-b4d2-3ccba44e0ab8)
 
 ## Regenerate the mesh
 
@@ -447,13 +447,13 @@ Note, the modified `"inner"` boundary chain with a more complicated curve influe
 maximum $L^2$ and $H^1$ errors along the inner boundary, whereas the errors for the outer boundary remain the same.
 The visualization updates automatically and the background grid is *removed* after when the mesh is generated.
 
-![inner_modified](https://user-images.githubusercontent.com/25242486/175063283-b60d8985-0fce-4010-90c5-5a924883a895.png)
+![inner_modified](https://github.com/user-attachments/assets/432ee9c7-c216-4c38-85f0-c5271a3a8175)
 
 Inspecting the mesh we see that the automatic subdivision in HOHQMesh does well to capture the sharp corners and fine features of the curved inner and outer boundaries. For example, we zoom
 into sharp corner at the bottom of the domain and see that, although small, the elements in this
 region maintain a good quadrilateral shape.
 
-![zoom_corner](https://user-images.githubusercontent.com/25242486/175063320-57d42322-2d0e-4e69-b177-ab40d6a8df3d.png)
+![zoom_corner](https://github.com/user-attachments/assets/8586077b-61e6-4065-b47e-419409273cd5)
 
 ## Summary
 

--- a/docs/src/tutorials/create_edit_curves.md
+++ b/docs/src/tutorials/create_edit_curves.md
@@ -187,7 +187,7 @@ inner_line2 = newEndPointsLineCurve("Line2",          # curve name
 To create the circle arcs we use the function `newCircularArcCurve` where
 we specify a name for the curve as well as the radius and center of the circle.
 In order to create an inner curve chain with counter-clockwise orientation the
-angle for the bottom half-circle arc centered at $(0, 3)$ varies from $-1800$ to $0$
+angle for the bottom half-circle arc centered at $(0, 3)$ varies from $-180$ to $0$
 degrees. The top half-circle arc centered at $(0, 5)$ has an angle that varies from
 $0$ to $180$ degrees. The construction of the two circle arcs are
 ```julia

--- a/docs/src/tutorials/create_edit_curves.md
+++ b/docs/src/tutorials/create_edit_curves.md
@@ -222,7 +222,7 @@ addCurveToInnerBoundary!(sandbox_project, inner_bottom_arc, "inner")
 This inner boundary chain name `"inner"` is used internally by HOHQMesh. The visualization
 of the background grid automatically detects that curves have been added to the
 `sandbox_project` and the plot is updated, as shown below. The chain for the inner boundary curve chain is called `inner` and it contains a four curve segments
-`"Line1"`, `"BottomArc"`, `"Line2"`, and `"TopArc"` labeled in the figure by
+`"Line1"`, `"TopArc"`, `"Line2"`, and `"BottomArc"` labeled in the figure by
 `1.1`, `1.2`, `1.3`, and `1.4`, respectively.
 
 ![inner_pill](https://user-images.githubusercontent.com/25242486/175062834-91aae24d-167d-4d0f-8d39-887ab189081b.png)
@@ -394,7 +394,7 @@ Note that the inner curve chain indexing has, again, been automatically adjusted
 ![inner_remove_arc](https://user-images.githubusercontent.com/25242486/175063146-9475697a-3aa8-42c1-abdb-713343c6b8f7.png)
 
 A half-circle arc that joins the points $(-1, 3)$ and $(2, 3)$ has a radius $r=1.5$,
-is centered at $(0.5, 3)$ and has an angle that vaires from $-180$ to $0$.
+is centered at $(0.5, 3)$ and has an angle that varies from $-180$ to $0$.
 We construct this circle arc and directly add it to the `sandbox_project`.
 ```julia
 new_bottom_arc = newCircularArcCurve("wideBottomArc", # curve name
@@ -443,9 +443,9 @@ generate_mesh(sandbox_project)
                   Outer Boundary  2.17883727E-06  6.23052073E-04
                            inner  8.43706312E-09  5.16278275E-06
 ```
-The visualization updates automatically and the background grid is *removed* after when the mesh is generated.
 Note, the modified `"inner"` boundary chain with a more complicated curve influences the
 maximum $L^2$ and $H^1$ errors along the inner boundary, whereas the errors for the outer boundary remain the same.
+The visualization updates automatically and the background grid is *removed* after when the mesh is generated.
 
 ![inner_modified](https://user-images.githubusercontent.com/25242486/175063283-b60d8985-0fce-4010-90c5-5a924883a895.png)
 

--- a/docs/src/tutorials/create_edit_curves.md
+++ b/docs/src/tutorials/create_edit_curves.md
@@ -167,42 +167,42 @@ with the new `"Spline"` curve labeled `O.3`.
 ## Add an inner boundary chain
 
 We create a pill shaped inner boundary curve chain composed of four pieces
-1. Straight line segment from $(1, 5)$ to $(1, 3)$.
-2. Half-circle arc of radius $r=1$ centered at $(0, 3)$.
-3. Straight line segment from $(-1, 3)$ to $(-1, 5)$.
-4. Half-circle arc of radius $r=1$ centered at $(0, 5)$.
+1. Straight line segment from $(1, 3)$ to $(1, 5)$.
+2. Half-circle arc of radius $r=1$ centered at $(0, 5)$.
+3. Straight line segment from $(-1, 5)$ to $(-1, 3)$.
+4. Half-circle arc of radius $r=1$ centered at $(0, 3)$.
 
 Similar to the construction of the `"Outer"` boundary chain, each segment of
 this inner boundary chain is created separately. The straight line segments are
 made with the function `newEndPointsLineCurve` and given unique names:
 ```julia
 inner_line1 = newEndPointsLineCurve("Line1",         # curve name
-                                    [1.0, 5.0, 0.0], # start point
-                                    [1.0, 3.0, 0.0]) # end point
+                                    [1.0, 3.0, 0.0], # start point
+                                    [1.0, 5.0, 0.0]) # end point
 
 inner_line2 = newEndPointsLineCurve("Line2",          # curve name
-                                    [-1.0, 3.0, 0.0], # start point
-                                    [-1.0, 5.0, 0.0]) # end point
+                                    [-1.0, 5.0, 0.0], # start point
+                                    [-1.0, 3.0, 0.0]) # end point
 ```
 To create the circle arcs we use the function `newCircularArcCurve` where
 we specify a name for the curve as well as the radius and center of the circle.
 In order to create an inner curve chain with counter-clockwise orientation the
-angle for the bottom half-circle arc centered at $(0, 3)$ varies from $0$ to $-180$
+angle for the bottom half-circle arc centered at $(0, 3)$ varies from $-1800$ to $0$
 degrees. The top half-circle arc centered at $(0, 5)$ has an angle that varies from
-$180$ to $0$ degrees. The construction of the two circle arcs are
+$0$ to $180$ degrees. The construction of the two circle arcs are
 ```julia
 inner_bottom_arc = newCircularArcCurve("BottomArc",     # curve name
                                        [0.0, 3.0, 0.0], # center
                                        1.0,             # radius
-                                       0.0,             # start angle
-                                       -pi,             # end angle
+                                       -pi,             # start angle
+                                       0,               # end angle
                                        "radians")       # units for angle
 
 inner_top_arc = newCircularArcCurve("TopArc",        # curve name
                                     [0.0, 5.0, 0.0], # center
                                     1.0,             # radius
-                                    180.0,           # start angle
-                                    0.0,             # end angle
+                                    0.0,             # start angle
+                                    180.0,           # end angle
                                     "degrees")       # units for angle
 ```
 Note, we use `"radians"` to set the angle bounds for `inner_bottom_arc` and `"degrees"`
@@ -212,12 +212,12 @@ The curve names  `"Line1"`, `"Line2"`, `"BottomArc"`, and `"TopArc"` are the lab
 HOHQMesh will give to these inner boundary curve segments in the resulting mesh file.
 
 The four curve segments stored in the variables `inner_line1`, `inner_line2`,
-`inner_bottom_arc` and `outer_arc` are added to the `sandbox_project` in  counter-clockwise order as required by HOHQMesh.
+`inner_bottom_arc` and `outer_arc` are added to the `sandbox_project` in counter-clockwise order as required by HOHQMesh.
 ```julia
 addCurveToInnerBoundary!(sandbox_project, inner_line1,      "inner")
-addCurveToInnerBoundary!(sandbox_project, inner_bottom_arc, "inner")
-addCurveToInnerBoundary!(sandbox_project, inner_line2,      "inner")
 addCurveToInnerBoundary!(sandbox_project, inner_top_arc,    "inner")
+addCurveToInnerBoundary!(sandbox_project, inner_line2,      "inner")
+addCurveToInnerBoundary!(sandbox_project, inner_bottom_arc, "inner")
 ```
 This inner boundary chain name `"inner"` is used internally by HOHQMesh. The visualization
 of the background grid automatically detects that curves have been added to the
@@ -243,25 +243,31 @@ generate_mesh(sandbox_project)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =    7.5414000000000009E-002
-    Number of nodes        =          511
-    Number of Edges        =          933
-    Number of Elements     =          422
+    Total time             =    8.7094999999999978E-002
+    Number of nodes        =          550
+    Number of Edges        =         1005
+    Number of Elements     =          455
     Number of Subdivisions =            7
 
  Mesh Quality:
          Measure         Minimum         Maximum         Average  Acceptable Low Acceptable High       Reference
-     Signed Area      0.00002932      1.17335568      0.18813138      0.00000000    999.99900000      1.00000000
-    Aspect Ratio      1.00953438      2.30790024      1.31439620      1.00000000    999.99900000      1.00000000
-       Condition      1.00041663      2.41773865      1.21024584      1.00000000      4.00000000      1.00000000
-      Edge Ratio      1.01673809      3.68828437      1.59413340      1.00000000      4.00000000      1.00000000
-        Jacobian      0.00001750      1.13820387      0.14143901      0.00000000    999.99900000      1.00000000
-   Minimum Angle     32.22733574     89.35690571     68.75321248     40.00000000     90.00000000     90.00000000
-   Maximum Angle     90.61089476    152.37947944    113.36221513     90.00000000    135.00000000     90.00000000
+     Signed Area      0.00002932      1.17365275      0.17469787      0.00000000    999.99900000      1.00000000
+    Aspect Ratio      1.00972172      2.30790024      1.29940314      1.00000000    999.99900000      1.00000000
+       Condition      1.00056710      2.41773865      1.19468261      1.00000000      4.00000000      1.00000000
+      Edge Ratio      1.02257329      3.68828437      1.56695245      1.00000000      4.00000000      1.00000000
+        Jacobian      0.00001750      1.13830581      0.13217004      0.00000000    999.99900000      1.00000000
+   Minimum Angle     32.22733574     89.47760655     69.43772947     40.00000000     90.00000000     90.00000000
+   Maximum Angle     90.69193236    152.37947944    112.53677771     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error     Max H1 Error
+                  Outer Boundary  2.17883727E-06  6.23052073E-04
+                           inner  1.06679487E-10  7.27142966E-08
 ```
-The call to `generate_mesh` also prints mesh quality statistics to the screen
-and updates the visualization.
+The call to `generate_mesh` prints mesh quality statistics to the screen and updates the visualization.
+The HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the curved outer and inner boundaries
+where the inner boundary error information is given by the chain name.
 The background grid is *removed* from the visualization when the mesh is generated.
 
 !!! note "Mesh visualization"
@@ -334,8 +340,8 @@ The new inner curve segment will be an oscillating line given by the
 parametric equations
 ```math
   \begin{aligned}
-    x(t) &= t + 1,\\[0.2cm]
-    y(t) &= -2t + 5 - \frac{3}{2} \cos(\pi t) \sin(\pi t),\\[0.2cm]
+    x(t) &= 2 - t,\\[0.2cm]
+    y(t) &= -2(1 - t) + 5 - \frac{3}{2} \cos(\pi (1 - t)) \sin(\pi (1 - t)),\\[0.2cm]
     z(t) &= 0
   \end{aligned}
   \qquad
@@ -346,8 +352,8 @@ available in Fortran, e.g., $\sin$, $\cos$, exp.
 The constant `pi` is available for use.
 The following commands create a new curve for the parametric equations above
 ```julia
-xEqn = "x(t) = t + 1"
-yEqn = "y(t) = -2 * t + 5 - 1.5 * cos(pi * t) * sin(pi * t)"
+xEqn = "x(t) = 2 - t"
+yEqn = "y(t) = -2 * (1 - t) + 5 - 1.5 * cos(pi * (1 - t)) * sin(pi * (1 - t))"
 zEqn = "z(t) = 0.0"
 inner_eqn = newParametricEquationCurve("wiggleLine", xEqn, yEqn, zEqn)
 ```
@@ -360,11 +366,13 @@ The automatically updated figure now shows:
 
 ![inner_open_chain](https://user-images.githubusercontent.com/25242486/175063103-e8eda78c-b0d9-4229-9383-5582845d5f81.png)
 
-We see from the figure that this parametric equation curve starts at the point $(1,5)$
-and, therefore, matches the end point of the existing curve `"TopArc"` present
-in the `"inner"` chain. However, the
-parametric equation curve ends at the point $(2,3)$ which **does not** match
-the `"BottomArc"` curve. So, the inner boundary chain remains open.
+We see from the figure and form of the parametric equations $x(t)$ and $y(t)$
+have that the parametric equation curve starts at the point $(x(0), y(0)) = (2, 3)$
+and terminates at the point $(x(1), y(1)) = (1, 5)$.
+So, the end point of the new curve `"wiggleLine"` joins to initial point
+of the existing curve `"TopArc"` present in the `"inner"` chain.
+However, the parametric equation curve begins at the point $(2,3)$ which **does not** match
+the end point of the `"BottomArc"` curve. So, the inner boundary chain is open.
 
 !!! warning "Attempt to generate a mesh with an open curve chain"
     An open curve chain is **invalid** in HOHQMesh. All inner and/or outer curve chains
@@ -374,7 +382,7 @@ the `"BottomArc"` curve. So, the inner boundary chain remains open.
 
 To create a closed boundary curve we must remove the `"BottomArc"` curve and replace it
 with a wider half-circle arc segment. This new half-circle arc must start at the point
-$(2, 3)$ and end at the point $(-1, 3)$ to close the inner chain **and** guarantee the
+$(-1, 3)$ and end at the point $(2, 3)$ to close the inner chain **and** guarantee the
 chain is oriented counter-clockwise. So, we first remove the `"BottomArc"` from the `"inner"`
 chain.
 ```julia
@@ -385,20 +393,20 @@ Note that the inner curve chain indexing has, again, been automatically adjusted
 
 ![inner_remove_arc](https://user-images.githubusercontent.com/25242486/175063146-9475697a-3aa8-42c1-abdb-713343c6b8f7.png)
 
-A half-circle arc that joins the points $(2, 3)$ and $(-1, 3)$ has a radius $r=1.5$, is
-centered at $(0.5, 3)$ and has an angle that vaires from $0$ to $-180$.
+A half-circle arc that joins the points $(-1, 3)$ and $(2, 3)$ has a radius $r=1.5$,
+is centered at $(0.5, 3)$ and has an angle that vaires from $-180$ to $0$.
 We construct this circle arc and directly add it to the `sandbox_project`.
 ```julia
 new_bottom_arc = newCircularArcCurve("wideBottomArc", # curve name
                                      [0.5, 3.0, 0.0], # center
                                      1.5,             # radius
-                                     0.0,             # start angle
-                                     -pi,             # end angle
+                                     -pi,             # start angle
+                                     0.0,             # end angle
                                      "radians")       # units for angle
 addCurveToInnerBoundary!(sandbox_project, new_bottom_arc, "inner")
 ```
 The updated plot now gives the modified, closed inner curve chain that now contains
-four curve segments `"Line2"`, `"TopArc"`, `"wiggleLine"`, and `"wideBottomArc"` labeled
+four curve segments `"TopArc"`, `"Line2"`, `"wideBottomArc"`, and `"wiggleLine"` labeled
 in the figure by `1.1`, `1.2`, `1.3`, and `1.4`, respectively.
 
 ![inner_modified](https://user-images.githubusercontent.com/25242486/175063184-9c2d1204-cdcd-4a33-88bd-d73e7183b3d6.png)
@@ -413,24 +421,31 @@ generate_mesh(sandbox_project)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =   0.11353599999999998
-    Number of nodes        =          712
-    Number of Edges        =         1308
-    Number of Elements     =          596
+   Total time             =   0.14115699999999998
+    Number of nodes        =          784
+    Number of Edges        =         1443
+    Number of Elements     =          659
     Number of Subdivisions =            7
 
  Mesh Quality:
          Measure         Minimum         Maximum         Average  Acceptable Low Acceptable High       Reference
-     Signed Area      0.00002932      1.15661960      0.12823902      0.00000000    999.99900000      1.00000000
-    Aspect Ratio      1.01050856      3.14732001      1.34260027      1.00000000    999.99900000      1.00000000
-       Condition      1.00037771      2.59434067      1.22850175      1.00000000      4.00000000      1.00000000
-      Edge Ratio      1.02744717      3.68828437      1.64751502      1.00000000      4.00000000      1.00000000
-        Jacobian      0.00001750      1.13149451      0.09443920      0.00000000    999.99900000      1.00000000
-   Minimum Angle     31.87236189     89.33988565     67.86178629     40.00000000     90.00000000     90.00000000
-   Maximum Angle     90.44177106    157.27121105    114.35699650     90.00000000    135.00000000     90.00000000
+     Signed Area      0.00002932      1.15443433      0.11616857      0.00000000    999.99900000      1.00000000
+    Aspect Ratio      1.00771124      2.34022215      1.29146302      1.00000000    999.99900000      1.00000000
+       Condition      1.00058000      2.47008143      1.19182565      1.00000000      4.00000000      1.00000000
+      Edge Ratio      1.02326019      3.68828437      1.55318354      1.00000000      4.00000000      1.00000000
+        Jacobian      0.00001750      1.13163339      0.08983973      0.00000000    999.99900000      1.00000000
+   Minimum Angle     32.22733574     88.97793734     69.85287528     40.00000000     90.00000000     90.00000000
+   Maximum Angle     90.70043468    152.37947955    112.33453717     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error     Max H1 Error
+                  Outer Boundary  2.17883727E-06  6.23052073E-04
+                           inner  8.43706312E-09  5.16278275E-06
 ```
 The visualization updates automatically and the background grid is *removed* after when the mesh is generated.
+Note, the modified `"inner"` boundary chain with a more complicated curve influences the
+maximum $L^2$ and $H^1$ errors along the inner boundary, whereas the errors for the outer boundary remain the same.
 
 ![inner_modified](https://user-images.githubusercontent.com/25242486/175063283-b60d8985-0fce-4010-90c5-5a924883a895.png)
 
@@ -492,15 +507,15 @@ outer_spline = newSplineCurve("Spline", 5, spline_data)
 addCurveToOuterBoundary!(sandbox_project, outer_spline)
 
 # Create and add the inner boundary curves
-inner_line1 = newEndPointsLineCurve("Line1", [1.0, 5.0, 0.0], [1.0, 3.0, 0.0])
-inner_line2 = newEndPointsLineCurve("Line2", [-1.0, 3.0, 0.0], [-1.0, 5.0, 0.0])
-inner_bottom_arc = newCircularArcCurve("BottomArc", [0.0, 3.0, 0.0], 1.0, 0.0, -pi, "radians")
-inner_top_arc = newCircularArcCurve("TopArc", [0.0, 5.0, 0.0], 1.0, 180.0, 0.0, "degrees")
+inner_line1 = newEndPointsLineCurve("Line1", [1.0, 3.0, 0.0], [1.0, 5.0, 0.0])
+inner_line2 = newEndPointsLineCurve("Line2", [-1.0, 5.0, 0.0], [-1.0, 3.0, 0.0])
+inner_bottom_arc = newCircularArcCurve("BottomArc", [0.0, 3.0, 0.0], 1.0, -pi, 0.0, "radians")
+inner_top_arc = newCircularArcCurve("TopArc", [0.0, 5.0, 0.0], 1.0, 0.0, 180.0, "degrees")
 
 addCurveToInnerBoundary!(sandbox_project, inner_line1, "inner")
-addCurveToInnerBoundary!(sandbox_project, inner_bottom_arc, "inner")
-addCurveToInnerBoundary!(sandbox_project, inner_line2, "inner")
 addCurveToInnerBoundary!(sandbox_project, inner_top_arc, "inner")
+addCurveToInnerBoundary!(sandbox_project, inner_line2, "inner")
+addCurveToInnerBoundary!(sandbox_project, inner_bottom_arc, "inner")
 
 # Generate a mesh
 generate_mesh(sandbox_project)
@@ -512,12 +527,12 @@ remove_mesh!(sandbox_project)
 removeInnerBoundaryCurve!(sandbox_project, "Line1", "inner")
 removeInnerBoundaryCurve!(sandbox_project, "BottomArc", "inner")
 
-xEqn = "x(t) = t + 1"
-yEqn = "y(t) = -2 * t + 5 - 1.5 * cos(pi * t) * sin(pi * t)"
+xEqn = "x(t) = 2 - t"
+yEqn = "y(t) = -2 * (1 - t) + 5 - 1.5 * cos(pi * (1 - t)) * sin(pi * (1 - t))"
 zEqn = "z(t) = 0.0"
 inner_eqn = newParametricEquationCurve("wiggleLine", xEqn, yEqn, zEqn)
 
-new_bottom_arc = newCircularArcCurve("wideBottomArc", [0.5, 3.0, 0.0], 1.5, 0.0, -pi, "radians")
+new_bottom_arc = newCircularArcCurve("wideBottomArc", [0.5, 3.0, 0.0], 1.5, -pi, 0.0, "radians")
 
 addCurveToInnerBoundary!(sandbox_project, inner_eqn, "inner")
 addCurveToInnerBoundary!(sandbox_project, new_bottom_arc, "inner")

--- a/docs/src/tutorials/curved_outer_boundary.md
+++ b/docs/src/tutorials/curved_outer_boundary.md
@@ -126,7 +126,7 @@ generate_mesh(blob_project)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =    8.4328000000000000E-002
+    Total time             =   0.12631000000000001
     Number of nodes        =          479
     Number of Edges        =          895
     Number of Elements     =          417
@@ -142,9 +142,14 @@ generate_mesh(blob_project)
    Minimum Angle     29.38249259     89.99827733     73.08294187     40.00000000     90.00000000     90.00000000
    Maximum Angle     90.00132795    156.98701187    109.36585212     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error    Max H1 Error
+                  Outer Boundary  4.79189227E-05  1.58057740E-02
 ```
-The call to `generate_mesh` also prints mesh quality statistics to the screen and updates the
-visualization. The background grid is *removed* from the visualization when the mesh is generated.
+The call to `generate_mesh` prints mesh quality statistics to the screen and updates the visualization.
+The HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the curved outer boundary.
+The background grid is *removed* from the visualization when the mesh is generated.
 
 !!! note "Mesh visualization"
     Currently, only the "skeleton" of the mesh is visualized. Thus, the high-order curved boundary information
@@ -176,7 +181,7 @@ generate_mesh(blob_project)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =    9.2778999999999986E-002
+    Total time             =   0.11993200000000000
     Number of nodes        =          503
     Number of Edges        =          940
     Number of Elements     =          438
@@ -192,8 +197,13 @@ generate_mesh(blob_project)
    Minimum Angle     29.38249259     89.99827897     72.80049710     40.00000000     90.00000000     90.00000000
    Maximum Angle     90.00132784    156.98701188    109.63478104     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error    Max H1 Error
+                  Outer Boundary  7.75495247E-06  3.51290592E-03
 ```
 Note, the circular region indicating the refinement center is removed from the plot when the mesh is generated.
+The addition of a targeted refinement region also reduced the maximum $L^2$ and $H^1$ errors of the new mesh.
 
 ![final_blob](https://user-images.githubusercontent.com/25242486/174747066-a804bf1d-508a-480d-bde3-47687b402604.png)
 

--- a/docs/src/tutorials/spline_curves.md
+++ b/docs/src/tutorials/spline_curves.md
@@ -238,7 +238,7 @@ generate_mesh(spline_project)
 ```
 The call to `generate_mesh` prints mesh quality statistics to the screen.
 The HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the curved outer and inner boundaries
-where the inner boundary error information is listed according to the chain name.
+where the inner boundaries error information is listed according to the chain name.
 HOHQMesh also reports mesh clean-up that occurred during the generation process, in this case the removal of
 "bad" chevron shaped elements that were present within the automatic subdivision procedure.
 The visualization updates automatically and the background grid is *removed* after when the mesh is generated.

--- a/docs/src/tutorials/spline_curves.md
+++ b/docs/src/tutorials/spline_curves.md
@@ -212,7 +212,7 @@ generate_mesh(spline_project)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =   0.25359100000000001
+    Total time             =   0.26175499999999996
     Number of nodes        =         1176
     Number of Edges        =         2225
     Number of Elements     =         1047
@@ -228,8 +228,17 @@ generate_mesh(spline_project)
    Minimum Angle     37.24189766     89.96174556     74.42003031     40.00000000     90.00000000     90.00000000
    Maximum Angle     90.03128071    157.35065162    107.91806148     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error     Max H1 Error
+                  Outer Boundary  1.45176294E-11  8.54200650E-09
+                          inner1  5.30146973E-06  1.71519711E-03
+                          inner2  4.19784789E-07  2.05657113E-04
+                          inner3  1.63284650E-03  5.25449390E-01
 ```
-The call to `generate_mesh` also prints mesh quality statistics to the screen.
+The call to `generate_mesh` prints mesh quality statistics to the screen.
+The HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the curved outer and inner boundaries
+where the inner boundary error information is listed according to the chain name.
 HOHQMesh also reports mesh clean-up that occurred during the generation process, in this case the removal of
 "bad" chevron shaped elements that were present within the automatic subdivision procedure.
 The visualization updates automatically and the background grid is *removed* after when the mesh is generated.

--- a/docs/src/tutorials/straight_outer_boundary.md
+++ b/docs/src/tutorials/straight_outer_boundary.md
@@ -171,7 +171,7 @@ generate_mesh(box_project)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =    2.9116999999999997E-002
+    Total time             =    3.1403999999999994E-002
     Number of nodes        =          498
     Number of Edges        =          921
     Number of Elements     =          422
@@ -187,9 +187,17 @@ generate_mesh(box_project)
    Minimum Angle     50.57680338     89.99999787     83.84338772     40.00000000     90.00000000     90.00000000
    Maximum Angle     90.00000259    136.97085026     96.70176380     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error     Max H1Error
+                          inner1  2.95974632E-08  7.37673074E-06
+                          inner2  2.73798428E-09  1.17828281E-06
 ```
-The call to `generate_mesh` also prints mesh quality statistics to the screen and updates the
-visualization. The background grid is *removed* from the visualization when the mesh is generated and the resulting
+The call to `generate_mesh` prints mesh quality statistics to the screen and updates the
+visualization.
+The HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the curved inner boundaries
+where the information is listed according to the chain name.
+The background grid is *removed* from the visualization when the mesh is generated and the resulting
 mesh is visualized instead.
 
 ![final_circle](https://user-images.githubusercontent.com/25242486/174775040-e4a04503-83f3-4f80-b087-972bd8dbb5e9.png)

--- a/docs/src/tutorials/straight_outer_boundary.md
+++ b/docs/src/tutorials/straight_outer_boundary.md
@@ -189,7 +189,7 @@ generate_mesh(box_project)
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
 
  Boundary Error Quality:
-                   Boundary Name    Max L2 Error     Max H1Error
+                   Boundary Name    Max L2 Error    Max H1 Error
                           inner1  2.95974632E-08  7.37673074E-06
                           inner2  2.73798428E-09  1.17828281E-06
 ```

--- a/docs/src/tutorials/symmetric_mesh.md
+++ b/docs/src/tutorials/symmetric_mesh.md
@@ -134,8 +134,8 @@ project in counter-clockwise order
 ```julia
 addCurveToOuterBoundary!(symmetric_mesh, line1)
 addCurveToOuterBoundary!(symmetric_mesh, line2)
-addCurveToOuterBoundary!(symmetric_mesh, half_circle)
 addCurveToOuterBoundary!(symmetric_mesh, line3)
+addCurveToOuterBoundary!(symmetric_mesh, half_circle)
 addCurveToOuterBoundary!(symmetric_mesh, line4)
 addCurveToOuterBoundary!(symmetric_mesh, line5)
 addCurveToOuterBoundary!(symmetric_mesh, line6)
@@ -171,7 +171,7 @@ generate_mesh(symmetric_mesh)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =    4.0154999999999996E-002
+    Total time             =    4.4701999999999992E-002
     Number of nodes        =          343
     Number of Edges        =          626
     Number of Elements     =          284
@@ -179,17 +179,22 @@ generate_mesh(symmetric_mesh)
 
  Mesh Quality:
          Measure         Minimum         Maximum         Average  Acceptable Low Acceptable High       Reference
-     Signed Area      0.00227157      0.06552808      0.01366911      0.00000000    999.99900000      1.00000000
-    Aspect Ratio      1.00389317      2.07480912      1.22443835      1.00000000    999.99900000      1.00000000
-       Condition      1.00048947      1.93007666      1.12853177      1.00000000      4.00000000      1.00000000
-      Edge Ratio      1.00607156      3.56541719      1.44892631      1.00000000      4.00000000      1.00000000
-        Jacobian      0.00158627      0.06202757      0.01120120      0.00000000    999.99900000      1.00000000
-   Minimum Angle     48.35050023     89.33703938     75.39251039     40.00000000     90.00000000     90.00000000
-   Maximum Angle     90.94150752    129.91539960    106.20679399     90.00000000    135.00000000     90.00000000
+     Signed Area      0.00220407      0.06242615      0.01366911      0.00000000    999.99900000      1.00000000
+    Aspect Ratio      1.01394925      2.04605013      1.20933780      1.00000000    999.99900000      1.00000000
+       Condition      1.00090927      1.63712117      1.11296179      1.00000000      4.00000000      1.00000000
+      Edge Ratio      1.01202453      2.93333325      1.41191150      1.00000000      4.00000000      1.00000000
+        Jacobian      0.00153988      0.05762182      0.01128942      0.00000000    999.99900000      1.00000000
+   Minimum Angle     49.13177233     89.02555379     75.90857703     40.00000000     90.00000000     90.00000000
+   Maximum Angle     91.06976230    130.32470794    105.68124689     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error    Max H1 Error
+                  Outer Boundary  2.97126900E-12  5.26628911E-09
 ```
 Note that the call to `generate_mesh` prints mesh quality statistics to the screen
 and updates the visualization.
+The HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the outer boundary.
 The background grid is *removed* from the visualization when the mesh is generated.
 
 !!! note "Mesh visualization"
@@ -228,7 +233,7 @@ Next, we rename all the co-linear boundary curves `O.3`, `O.5`, and `O.9` to hav
 Both are done with the function `renameCurve!`
 ```julia
 renameCurve!(symmetric_mesh, ":symmetry", # existing curve name
-                             "left")     # new curve name
+                             "left")      # new curve name
 renameCurve!(symmetric_mesh, "right", ":symmetry")
 ```
 After the boundary names are adjusted the plot updates automatically to give the figure below.
@@ -236,8 +241,8 @@ After the boundary names are adjusted the plot updates automatically to give the
 ![before_generation2](https://github.com/trixi-framework/HOHQMesh.jl/assets/25242486/0118a02f-0343-4280-8a63-eba5a59d69e3)
 
 We then generate the new mesh from the information contained in `symmetric_mesh`.
-Again, a check ensures that the curves designated as `":symmetry"` are co-linear. 
-An error is thrown if this is not the case and the mesh will not be reflected. 
+Again, a check ensures that the curves designated as `":symmetry"` are co-linear.
+An error is thrown if this is not the case and the mesh will not be reflected.
 This saves the control, tec, and mesh files into the `out` folder and yields
 ```julia
 generate_mesh(symmetric_mesh)
@@ -245,7 +250,7 @@ generate_mesh(symmetric_mesh)
  *******************
  2D Mesh Statistics:
  *******************
-    Total time             =    3.7763000000000019E-002
+    Total time             =    4.7195999999999988E-002
     Number of nodes        =          337
     Number of Edges        =          622
     Number of Elements     =          284
@@ -253,16 +258,22 @@ generate_mesh(symmetric_mesh)
 
  Mesh Quality:
          Measure         Minimum         Maximum         Average  Acceptable Low Acceptable High       Reference
-     Signed Area      0.00227157      0.06552808      0.01366911      0.00000000    999.99900000      1.00000000
-    Aspect Ratio      1.00389317      2.07480912      1.22443835      1.00000000    999.99900000      1.00000000
-       Condition      1.00048947      1.93007666      1.12853177      1.00000000      4.00000000      1.00000000
-      Edge Ratio      1.00607156      3.56541719      1.44892631      1.00000000      4.00000000      1.00000000
-        Jacobian      0.00158627      0.06202757      0.01120120      0.00000000    999.99900000      1.00000000
-   Minimum Angle     48.35050023     89.33703938     75.39251039     40.00000000     90.00000000     90.00000000
-   Maximum Angle     90.94150752    129.91539960    106.20679399     90.00000000    135.00000000     90.00000000
+     Signed Area      0.00200919      0.06472958      0.01366911      0.00000000    999.99900000      1.00000000
+    Aspect Ratio      1.01394929      2.04364136      1.21258194      1.00000000    999.99900000      1.00000000
+       Condition      1.00091018      1.91814253      1.12027830      1.00000000      4.00000000      1.00000000
+      Edge Ratio      1.01202453      3.53385826      1.42073382      1.00000000      4.00000000      1.00000000
+        Jacobian      0.00135817      0.06134810      0.01120294      0.00000000    999.99900000      1.00000000
+   Minimum Angle     43.09402469     89.33487540     75.97399519     40.00000000     90.00000000     90.00000000
+   Maximum Angle     90.57451347    143.07429487    105.78829265     90.00000000    135.00000000     90.00000000
        Area Sign      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000      1.00000000
+
+ Boundary Error Quality:
+                   Boundary Name    Max L2 Error    Max H1 Error
+                  Outer Boundary  2.97126900E-12  5.26628911E-09
 ```
-The updated visualization is given below. Note, the flexibility to define multiple
+The updated visualization is given below.
+Again, the HOHQMesh output also reports the maximum $L^2$ and $H^1$ errors along the outer boundary.
+Note, the flexibility to define multiple
 co-linear symmetric boundaries creates a symmetric mesh with closed internal boundaries.
 In this example, a circle and a rectangle.
 
@@ -277,10 +288,10 @@ In this tutorial we demonstrated how to:
 * Rename boundaries in an existing interactive mesh project.
 * Visualize an interactive mesh project.
 
-For completeness, we include two scripts with all the commands to generate the meshes displayed
+For completeness, we include in the script below all the commands to generate the meshes displayed
 for a reflection about the left boundary line `O.1` as well as a reflection about
 the right boundary composed of the three co-linear segments `O.3`, `O.5`, and `O.9`.
-Note, we **do not** include the plotting in these scripts.
+Note, we **do not** include the plotting in this scripts.
 ```julia
 # Interactive mesh with reflection on the left over a single symmetry boundary
 # as well as a reflection on the right over multiple co-linear symmetry boundaries.
@@ -337,8 +348,8 @@ line9 = newEndPointsLineCurve("top", [1.0, 2.0, 0.0],
 
 addCurveToOuterBoundary!(symmetric_mesh, line1)
 addCurveToOuterBoundary!(symmetric_mesh, line2)
-addCurveToOuterBoundary!(symmetric_mesh, half_circle)
 addCurveToOuterBoundary!(symmetric_mesh, line3)
+addCurveToOuterBoundary!(symmetric_mesh, half_circle)
 addCurveToOuterBoundary!(symmetric_mesh, line4)
 addCurveToOuterBoundary!(symmetric_mesh, line5)
 addCurveToOuterBoundary!(symmetric_mesh, line6)

--- a/examples/interactive_outer_box_two_circles.jl
+++ b/examples/interactive_outer_box_two_circles.jl
@@ -66,7 +66,7 @@ end
 
 # Generate the mesh. This produces the mesh and TecPlot files `box_two_circles.inp` and `box_two_circles.tec`
 # and saves them to the `out` folder. It also creates a control file `box_two_circles.control`.
-# Also, if there is an active plot in the project `p` it is updated with the mesh that was generated.
+# If there is an active plot in the project `p` it is updated with the mesh that was generated.
 
 generate_mesh(p)
 

--- a/examples/interactive_outer_box_two_circles.jl
+++ b/examples/interactive_outer_box_two_circles.jl
@@ -64,9 +64,9 @@ else # Throw an informational message about plotting to the user
    @info "To visualize the project (boundary curves, background grid, mesh, etc.), include `GLMakie` and run again."
 end
 
-# Generate the mesh. This produces the mesh and TecPlot files `AllFeatures.mesh` and `AllFeatures.tec`
-# and save them to the `out` folder. Also, if there is an active plot in the project `p` it is
-# updated with the mesh that was generated.
+# Generate the mesh. This produces the mesh and TecPlot files `box_two_circles.inp` and `box_two_circles.tec`
+# and saves them to the `out` folder. It also creates a control file `box_two_circles.control`.
+# Also, if there is an active plot in the project `p` it is updated with the mesh that was generated.
 
 generate_mesh(p)
 

--- a/examples/interactive_spline_curves.jl
+++ b/examples/interactive_spline_curves.jl
@@ -1,16 +1,16 @@
 # Interactive mesh with spline curves
 #
 # Create a mesh with a circular outer boundary and three inner boundaries.
-# Two inner boundaries are parametric splines, on econstructred from file data and
+# Two inner boundaries are parametric splines, are constructed from file data and
 # the other from given data points. The third curve is a triangular object built from
 # three internal straight-sided "curves".
 #
 # Keywords: spline from file, spline construction, outer boundary, inner boundary
 
-projectName = "spline_boundary"
+projectName = "spline_curves"
 projectPath = "out"
 
-# Create a new project with the name "spline_boundary", which will also be the
+# Create a new project with the name "spline_curves", which will also be the
 # name of the mesh, plot and stats files, written to output folder `out`.
 
 p = newProject(projectName, projectPath)
@@ -77,9 +77,9 @@ if isdefined(Main, :Makie)
     @info "To visualize the project (boundary curves, background grid, mesh, etc.), include `GLMakie` and run again."
  end
 
-# Generate the mesh. This produces the mesh and TecPlot files `IceCreamCone.mesh` and `IceCreamCone.tec`
-# and saves them to the `out` folder. Also, if there is an active plot in the project `p` it is
-# updated with the mesh that was generated.
+# Generate the mesh. This produces the mesh and TecPlot files `spline_curves.mesh` and `spline_curves.tec`
+# and saves them to the `out` folder. It also creates a control file `box_two_circles.control`.
+# If there is an active plot in the project `p` it is updated with the mesh that was generated.
 
 generate_mesh(p)
 

--- a/src/HOHQMesh.jl
+++ b/src/HOHQMesh.jl
@@ -231,9 +231,9 @@ function generate_mesh(control_file;
 
     # Run HOHQMesh and store output
     if verbose
-      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $subdivision_maximum -verbose -f $tmppath`)
+      rstrip(readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $subdivision_maximum -verbose -f $tmppath`))
     else
-      readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $subdivision_maximum -f $tmppath`)
+      rstrip(readchomp(`$(HOHQMesh_jll.HOHQMesh()) -sLimit $subdivision_maximum -f $tmppath`))
     end
   end
 


### PR DESCRIPTION
This adjusts the HOHQMesh output for all tutorials now that the maximum $L^2$ and $H^1$ errors are reported after meshing. Also, this corrects the incorrectly oriented inner boundary curve in the "Create and edit curves" tutorial.

Note, these update also reveal a subtle bug in the `:symmetry` boundary implementation. If there is a single symmetry boundary, then the meshing works without issue. However, with multiple colinear `:symmetry` boundaries some node information is lost and meshing fails. We are currently investigating the root cause of this behavior in the Fortran code.

Closes #112 