### PR TITLE
Update compat bound on HOHQMesh_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MakieExt = "Makie"
 
 [compat]
-HOHQMesh_jll = "=1.6.0"
+HOHQMesh_jll = "=1.6.1"
 Makie = "0.20, 0.24"
 Requires = "1.1.3"
 julia = "1.6"


### PR DESCRIPTION
With the release of HOHQMesh v1.6.1 it should be used here.