### PR TITLE
Add optimization keywords and ellipse functionality

### DIFF
--- a/docs/src/CheatSheet.md
+++ b/docs/src/CheatSheet.md
@@ -36,11 +36,12 @@ The `options` are any sum of `MODEL`, `GRID`, `REFINEMENTS`, and `MESH`.
 ## Curves
 
 ```
-   c = new(name, startLocation [x,y,z], endLocation [x,y,z])   *Straight Line*
-   c = new(name, center [x,y,z], radius, startAngle, endAngle) *Circular Arc*
-   c = new(name, xEqn, yEqn, zEqn)                             *Parametric equation*
-   c = new(name, dataFile)                                     *Spline with data from a file*
-   c = new(name, nKnots, knotsMatrix)                          *Spline with given knot values*
+   c = new(name, startLocation [x,y,z], endLocation [x,y,z])                       *Straight Line*
+   c = new(name, center [x,y,z], radius, startAngle, endAngle, units)                     *Circular Arc*
+   c = new(name, center [x,y,z], xRadius, yRadius, startAngle, endAngle, rotation, units) *Elliptic Arc*
+   c = new(name, xEqn, yEqn, zEqn)                                                 *Parametric equation*
+   c = new(name, dataFile)                                                         *Spline with data from a file*
+   c = new(name, nKnots, knotsMatrix)                                              *Spline with given knot values*
 ```
 
 Shown here is the use of the function `new`, which is a shortcut to the full functions, e.g. `newCircularArcCurve`, etc. which have the same arguments.

--- a/docs/src/guided-tour.md
+++ b/docs/src/guided-tour.md
@@ -95,12 +95,13 @@ The first line creates a new project, where the mesh and plot file names will be
 from the project name, "IceCreamCone" written to the specified folder.
 
 To develop the model, one adds curves to the outer boundary or to multiple inner boundaries,
-if desired. As in HOHQMesh, there are four curve classes currently available:
+if desired. As in HOHQMesh, there are five curve classes currently available:
 
 - Parametric equations
 - Cubic Splines
 - Lines defined by their end points
 - Circular arcs
+- Elliptic arcs
 
 In the example, the outer boundary is a closed circular arc with center at [0.0, 0.0, 0.0]
 with radius 4, starting at zero and ending at 360 degrees. It is added to the project with

--- a/docs/src/interactive-api.md
+++ b/docs/src/interactive-api.md
@@ -248,12 +248,13 @@ constructing, and removing curves from a `Project`.
 
 ### Defining curves
 
-Four curve types can be added to the outer and inner boundary curve chains. They are
+Five curve types can be added to the outer and inner boundary curve chains. They are
 
 - Parametric equations
 - Cubic Splines
 - Lines defined by their end points
 - Circular arcs
+- Elliptic arcs
 
 #### Parametric equations
 
@@ -349,6 +350,28 @@ It is either "degrees" or "radians". That argument is optional, and defaults to 
 Example:
 ```julia
    halfCircle = newCircularArcCurve("Dome", [0.0, 0.0, 0.0], 1.0, 0.0, 180.0, "degrees")
+```
+
+#### Elliptic arc
+```
+   [Return:Dict{String,Any}] newEllipticArcCurve(name::String,
+                                                 center::Array{Float64},
+                                                 xRadius::Float64,
+                                                 yRadius::Float64,
+                                                 startAngle::Float64,
+                                                 endAngle::Float64,
+                                                 rotation::Float64,
+                                                 units::String)
+```
+The center is an array of the form [x, y, z].
+The radii `xRadius` and `yRadius` define the major and minor axes of the ellipse.
+The angle `rotation` (which defaults to `0.0`) allows one to slant the elliptic arc.
+The units argument defines the start and end angle units.
+It is either "degrees" or "radians". That argument is optional, and defaults to "degrees".
+
+Example:
+```julia
+   halfEllipse = newEllipticArcCurve("Dome", [0.0, 0.0, 0.0], 3.0, 1.0, 0.0, 180.0, 45.0, "degrees")
 ```
 
 ### Adding and removing outer and inner boundaries
@@ -454,7 +477,8 @@ Otherwise there are special functions to change the parameters of curves
    [Return:nothing] setArcCenter!(arc::Dict{String,Any}, point::Array{Float64})
    [Return:nothing] setArcStartAngle!(arc::Dict{String,Any}, angle::Float64)
    [Return:nothing] setArcEndAngle!(arc::Dict{String,Any}, angle::Float64)
-   [Return:nothing] setArcRadius!(arc::Dict{String,Any}, radius::Float64)
+   [Return:nothing] setArcRadius!(arc::Dict{String,Any}, radius::Float64, key::String = "radius")
+   [Return:nothing] setArcRotation!(arc::Dict{String,Any}, rotation::Float64)
 
    [Return:String]         getXEqn(crv::Dict{String,Any})
    [Return:String]         getYEqn(crv::Dict{String,Any})
@@ -465,7 +489,8 @@ Otherwise there are special functions to change the parameters of curves
    [Return:Array{Float64}] getArcCenter(arc::Dict{String,Any})
    [Return:Float64]        getArcStartAngle(arc::Dict{String,Any})
    [Return:Float64]        getArcEndAngle(arc::Dict{String,Any})
-   [Return:Float64]        getArcRadius(arc::Dict{String,Any})
+   [Return:Float64]        getArcRadius(arc::Dict{String,Any}, key::String = "radius")
+   [Return:Float64]        getArcRotation(arc::Dict{String,Any})
 ```
 
 ## Undo/redo

--- a/docs/src/interactive_overview.md
+++ b/docs/src/interactive_overview.md
@@ -144,7 +144,9 @@ To generate a mesh interactively you
    plot the mesh as in the figure above, if a plot is otherwise visible.
    If not, it can always be plotted with the `plotProject!` command.
 
-## Advanced
+## Advanced features
+
+### Optional arguments for mesh generation
 
 The `generate_mesh` function has two optional arguments. The first is the Boolean `verbose`
 argument. One can pass `verbose=true` to output additional messages and information during
@@ -154,6 +156,53 @@ to a factor of `2^8` smaller than the existing background grid.
 Note, think before adjusting the `subdivision_maximum` level! It is often the case that
 adjusting the boundary curves, background grid size, adding local refinement regions,
 or some combination of these adjustments removes the need to adjust the subdivision depth.
+
+### Error controlled mesh adaptation
+
+HOHQMesh automatically sizes elements according to a number of criteria,
+including the local radius of curvature of the boundary curves,
+the distance between curves, and user-defined refinement regions.
+
+A new experimental feature allows HOHQMesh to adaptively mesh a model
+to provide optimal boundary approximations to the model curves with
+user-specified smoothness to within a user-defined tolerance.
+Refer to the HOHQMesh documentation for an [overview](https://trixi-framework.org/HOHQMesh/error-controlled-adaptive-meshing/)
+and [technical details](https://trixi-framework.org/HOHQMesh/boundary-curve-optimization-details/)
+of this strategy.
+
+Error control of the boundary curves is done chain-by-chain and can be performed in
+the `"OUTER_BOUNDARY"` chain and any one of the `"INNER_BOUNDARIES"`.
+This is done by telling HOHQMesh what norm to optimize ($L^2$ or $H^1$), the error tolerance, and to what derivatives the resulting boundary approximation will be smooth.
+The keywords (together with their default values) that control this optimization
+are given below.
+They are present in any `"CHAIN"` dictionary created in HOHQMesh.jl
+```julia
+   "optimize" = "none"  # options are "L2Norm", "H1Norm" or "none"
+   "tolerance" = "1e-3" # accuracy tolerance
+   "continuity" = "0"   # highest derivative to be made smooth
+   "connect" = "[]"     # see description below
+```
+More details on the options are:
+
+1. `"optimize"`: Specifies the norm to be minimized. For convenience, `"none"` is provided to deactivate the optimization.
+2. `"tolerance"`: The accuracy to which the boundaries are to be approximated.
+3. `"continuity"`: The derivatives to which the approximation will be constrained. For example, if second derivative continuity is to be enforced, choose `"continuity" = "2"`. If zero, then the approximation is simply continuous.
+4. `"connect"`: This *optional* parameter allows one to optimize across segments of a chain. By default, optimization is done curve by curve within the chain, since usually there will be discontinuities (e.g. corners) between the curves. If it is desired to define a more global approximation across multiple curves, include the `"connect"` key.
+
+ The syntax is the following:
+ ```julia
+    "connect" = "crv_1-crv_2,crv_3-crv_4,..."
+ ```
+ where the `crv_n` are the index of the curves in the chain. For example, if a chain contains ten curves and optimization is requested across the third and fourth curves in the list and across the sixth through ninth in the list, then
+ ```julia
+    "connect" = "3-4,6-9"
+ ```
+
+When active, HOHQMesh will then find the best polynomial approximation of each curve
+in the chain to the order defined by `polynomial order` in the `"RUN_PARAMETERS"`
+of the project (the default polynomial order is `5`).
+
+## Final note
 
 All objects and information contained in the variable type `Project` are actually dictionaries
 of type `Dict{String, Any}`.

--- a/docs/src/interactive_overview.md
+++ b/docs/src/interactive_overview.md
@@ -202,6 +202,32 @@ When active, HOHQMesh will then find the best polynomial approximation of each c
 in the chain to the order defined by `polynomial order` in the `"RUN_PARAMETERS"`
 of the project (the default polynomial order is `5`).
 
+One can adjust the values that control the boundary optimization for any of the boundary
+chains. There are specialized setter / getter functions for the `"OUTER_BOUNDARY"`
+(there is only one)
+```julia
+   setOuterBoundaryOptimizeStatus!(proj::Project, status::String)
+   getOuterBoundaryOptimizeStatus(proj::Project)
+   setOuterBoundaryTolerance!(proj::Project, tolerance::Float64)
+   getOuterBoundaryTolerance(proj::Project)
+   setOuterBoundaryContinuity!(proj::Project, continuity::Int)
+   getOuterBoundaryContinuity(proj::Project)
+   setOuterBoundaryConnect!(proj::Project, connect::String)
+   getOuterBoundaryConnect(proj::Project)
+```
+as well as any of the `"INNER_BOUNDARIES"` where the functions accept
+the `chainName` that should be queried or modified
+```julia
+   setInnerBoundaryChainOptimizeStatus!(proj::Project, chainName::String, status::String)
+   getInnerBoundaryChainOptimizeStatus(proj::Project, chainName::String)
+   setInnerBoundaryChainTolerance!(proj::Project, chainName::String, tolerance::Float64)
+   getInnerBoundaryChainTolerance(proj::Project, chainName::String)
+   setInnerBoundaryChainContinuity!(proj::Project, chainName::String, continuity::Int)
+   getInnerBoundaryChainContinuity(proj::Project, chainName::String)
+   setInnerBoundaryChainConnect!(proj::Project, chainName::String, connect::String)
+   getInnerBoundaryChainConnect(proj::Project, chainName::String)
+```
+
 ## Final note
 
 All objects and information contained in the variable type `Project` are actually dictionaries

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -83,7 +83,7 @@ A CIRCULAR_ARC block contains
    start angle
    end angle
 
-A ELLIPTIC_ARC block contains
+An ELLIPTIC_ARC block contains
    TYPE
    name
    units
@@ -336,7 +336,7 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
         if haskey(controlDict, key)
             value = controlDict[key]
 
-            println(f, "\\begin{$key}")
+            println(f, "\\begin", key, "}")
             WriteDictionary(value, f, deepIndent)
             println(f, "\\end{$key}")
             println(f, "")

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -168,6 +168,25 @@ const blocksThatStoreLists = Set(["OUTER_BOUNDARY",
 const blockRegex = r"(?<=\{).+?(?=\})"
 blockNameStack = []
 
+# Control file components order to force
+# CONTROL_INPUT to come first in the file
+# followed by the MODEL
+const projectOrder = ["CONTROL_INPUT", "MODEL"]
+
+# Order on the CONTROL_INPUT to match the HOHQMesh
+# documentation.
+const controlInputOrder = ["RUN_PARAMETERS",
+                           "BACKGROUND_GRID",
+                           "SPRING_SMOOTHER",
+                           "REFINEMENT_REGIONS"]
+
+# Boundary curve optimization keyword order
+const bndryOptKeywordOrder = ["name",
+                              "optimize",
+                              "tolerance",
+                              "continuity",
+                              "connect"]
+
 #
 #--------------- MAIN ENTRY -----------------------------------------------
 #
@@ -297,30 +316,83 @@ end
 function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::String)
 
     deepIndent = "   " * indent
-    for (key, value) in controlDict
-        if isa(value, AbstractDict)
-            println(f,indent,"\\begin{$key}")
-            if in(key,blocksThatStoreLists)
-                list = value["LIST"]
-                StepThroughList(list,f, deepIndent)
-            else
-                WriteDictionary(value,f, deepIndent)
+
+    # Ensure that CONTROL_INPUT comes first
+    # followed by the MODEL
+    for key in projectOrder
+        if haskey(controlDict, key)
+            value = controlDict[key]
+
+            println(f, "\\begin{$key}")
+            WriteDictionary(value, f, deepIndent)
+            println(f, "\\end{$key}")
+            println(f, "")
+        end
+    end
+
+    # Ensure that CONTROL_INPUT components
+    # match the order from the HOHQMesh docs
+    for key in controlInputOrder
+        if haskey(controlDict, key)
+            value = controlDict[key]
+
+            println(f, indent, "\\begin{$key}")
+            WriteDictionary(value, f, deepIndent)
+            println(f, indent, "\\end{$key}")
+            println(f, "")
+        end
+    end
+
+    # Write the optimization keywords in order
+    # to match the HOHQMesh documentation
+    for key in bndryOptKeywordOrder
+        if haskey(controlDict, key)
+            value = controlDict[key]
+
+#            # TODO: do we ant this skip?
+#            # Don't write an empty connect
+#            if key == "connect" && value == "[]"
+#                continue
+#            end
+
+            if isa(value, AbstractString)
+                if key != "TYPE"
+                    println(f, indent, "$key = $value")
+                end
             end
-            println(f,indent,"\\end{$key}")
+        end
+    end
+
+    # Write everything else where ordering doesn't matter
+    for (key, value) in controlDict
+        # Already handled above
+        if key in union(bndryOptKeywordOrder, projectOrder, controlInputOrder)
+            continue
+        end
+        if isa(value, AbstractDict)
+            println(f, indent, "\\begin{$key}")
+            WriteDictionary(value, f, deepIndent)
+            println(f, indent, "\\end{$key}")
+            println(f, "")
         elseif isa(value, AbstractString)
             if key != "TYPE"
-                println(f,indent,"$key = $value")
+                println(f, indent, "$key = $value")
             end
         elseif isa(value, AbstractArray)
             if key == "LIST"
-                StepThroughList(value,f, deepIndent)
+                StepThroughList(value, f, deepIndent)
             elseif key == "SPLINE_DATA"
-                println(f,indent,"\\begin{$key}")
+                println(f, indent, "\\begin{$key}")
                 arraySize = size(value)
                 for j = 1:arraySize[1]
-                    println(f,deepIndent, " ", value[j,1], " ", value[j,2], " ", value[j,3], " ", value[j,4])
+                    println(f, deepIndent, " ",
+                               value[j,1], " ",
+                               value[j,2], " ",
+                               value[j,3], " ",
+                               value[j,4])
                 end
-                println(f,indent,"\\end{$key}")
+                println(f, indent, "\\end{$key}")
+                println(f, "")
             end
         end
     end

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -34,6 +34,7 @@ The MODEL dictionary contains the keys
             SPLINE_CURVE
             END_POINTS_LINE
             CIRCULAR_ARC
+            ELLIPTIC_ARC
     INNER_BOUNDARIES
         The INNER_BOUNDARIES block contains a ["LIST"] of
             CHAIN
@@ -46,6 +47,7 @@ A CHAIN block contains a ["LIST"] of
      SPLINE_CURVE
      END_POINTS_LINE
      CIRCULAR_ARC
+     ELLIPTIC_ARC
 
 A PARAMETRIC_EQUATION_CURVE dictionary contains the keys
     TYPE
@@ -80,6 +82,17 @@ A CIRCULAR_ARC block contains
    radius
    start angle
    end angle
+
+A ELLIPTIC_ARC block contains
+   TYPE
+   name
+   units
+   center
+   xRadius
+   yRadius
+   start angle
+   end angle
+   rotation
 
 REFINEMENT_REGIONS dictionary contains the keys
    TYPE
@@ -248,6 +261,7 @@ function performImport(collection, f::IOStream)
 #
                     if blockName == "CHAIN"
                         nextLine = readline(f)
+                        println(nextLine)
                         kvp      = keyAndValueOnLine(nextLine)
                         if kvp === nothing
                             error("Key-value pair not found in string: " * nextLine)
@@ -349,16 +363,13 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
         if haskey(controlDict, key)
             value = controlDict[key]
 
-#            # TODO: do we want this skip?
-#            # Don't write an empty connect
-#            if key == "connect" && value == "[]"
-#                continue
-#            end
+            # Don't write out an empty connect keyword
+            if key == "connect" && value == "[]"
+                continue
+            end
 
-            if isa(value, AbstractString)
-                if key != "TYPE"
-                    println(f, indent, "$key = $value")
-                end
+            if isa(value, AbstractString) && key != "TYPE"
+                println(f, indent, "$key = $value")
             end
         end
     end

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -349,7 +349,7 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
         if haskey(controlDict, key)
             value = controlDict[key]
 
-#            # TODO: do we ant this skip?
+#            # TODO: do we want this skip?
 #            # Don't write an empty connect
 #            if key == "connect" && value == "[]"
 #                continue

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -336,9 +336,9 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
         if haskey(controlDict, key)
             value = controlDict[key]
 
-            println(f, "\\begin", key, "}")
+            println(f, "\\begin{", key, "}") # TODO: double check that this still works
             WriteDictionary(value, f, deepIndent)
-            println(f, "\\end{$key}")
+            println(f, "\\end{", key, "}")
             println(f, "")
         end
     end
@@ -349,9 +349,9 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
         if haskey(controlDict, key)
             value = controlDict[key]
 
-            println(f, indent, "\\begin{$key}")
+            println(f, indent, "\\begin{", key, "}")
             WriteDictionary(value, f, deepIndent)
-            println(f, indent, "\\end{$key}")
+            println(f, indent, "\\end{", key, "}")
             println(f, "")
         end
     end
@@ -368,7 +368,7 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
             end
 
             if isa(value, AbstractString) && key != "TYPE"
-                println(f, indent, "$key = $value")
+                println(f, indent, key, " = ", value)
             end
         end
     end
@@ -380,19 +380,19 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
             continue
         end
         if isa(value, AbstractDict)
-            println(f, indent, "\\begin{$key}")
+            println(f, indent, "\\begin{", key, "}")
             WriteDictionary(value, f, deepIndent)
-            println(f, indent, "\\end{$key}")
+            println(f, indent, "\\end{", key, "}")
             println(f, "")
         elseif isa(value, AbstractString)
             if key != "TYPE"
-                println(f, indent, "$key = $value")
+                println(f, indent, key, " = ", value)
             end
         elseif isa(value, AbstractArray)
             if key == "LIST"
                 StepThroughList(value, f, deepIndent)
             elseif key == "SPLINE_DATA"
-                println(f, indent, "\\begin{$key}")
+                println(f, indent, "\\begin{", key, "}")
                 arraySize = size(value)
                 for j = 1:arraySize[1]
                     println(f, deepIndent, " ",
@@ -401,7 +401,7 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
                                value[j,3], " ",
                                value[j,4])
                 end
-                println(f, indent, "\\end{$key}")
+                println(f, indent, "\\end{", key, "}")
                 println(f, "")
             end
         end
@@ -413,9 +413,9 @@ function StepThroughList(lst::AbstractArray,f::IOStream, indent::String)
     deepIndent = "   " * indent
     for dict in lst
         dtype = dict["TYPE"]
-        println(f,indent, "\\begin{$dtype}")
+        println(f,indent, "\\begin{", dtype, "}")
         WriteDictionary(dict,f, deepIndent)
-        println(f,indent, "\\end{$dtype}")
+        println(f,indent, "\\end{", dtype, "}")
     end
 end
 

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -261,7 +261,6 @@ function performImport(collection, f::IOStream)
 #
                     if blockName == "CHAIN"
                         nextLine = readline(f)
-                        println(nextLine)
                         kvp      = keyAndValueOnLine(nextLine)
                         if kvp === nothing
                             error("Key-value pair not found in string: " * nextLine)

--- a/src/ControlFile/ControlFileOperations.jl
+++ b/src/ControlFile/ControlFileOperations.jl
@@ -336,7 +336,7 @@ function WriteDictionary(controlDict::Dict{String,Any}, f::IOStream, indent::Str
         if haskey(controlDict, key)
             value = controlDict[key]
 
-            println(f, "\\begin{", key, "}") # TODO: double check that this still works
+            println(f, "\\begin{", key, "}")
             WriteDictionary(value, f, deepIndent)
             println(f, "\\end{", key, "}")
             println(f, "")

--- a/src/Curves/CurveOperations.jl
+++ b/src/Curves/CurveOperations.jl
@@ -1,17 +1,18 @@
 
 const argRegex = r"(?<=\().+?(?=\))"
 
-function arcCurvePoints(center::Array{Float64}, r::Float64, thetaStart::Float64, thetaEnd::Float64, units::AbstractString, t::Array{Float64}, points::Array{Float64,2})
+function arcCurvePoints(center::Array{Float64}, r::Float64, thetaStart::Float64, thetaEnd::Float64,
+                        units::AbstractString, t::Array{Float64}, points::Array{Float64,2})
     fctr::Float64 = 1.0
     if units == "degrees"
-        fctr = pi/180.0
+        fctr = pi / 180.0
     end
 
     theta::Float64 = 0.0
     for i = 1:length(t)
         theta = thetaStart + (thetaEnd - thetaStart)*t[i]
-        points[i,1] = center[1] + r*cos(theta*fctr)
-        points[i,2] = center[2] + r*sin(theta*fctr)
+        points[i,1] = center[1] + r * cos(theta * fctr)
+        points[i,2] = center[2] + r * sin(theta * fctr)
     end
 end
 
@@ -20,22 +21,59 @@ function arcCurvePoint(center::Array{Float64}, r::Float64, thetaStart::Float64, 
                        units::AbstractString, t::Float64, point::Array{Float64})
     fctr::Float64 = 1.0
     if units == "degrees"
-        fctr = pi/180.0
+        fctr = pi / 180.0
     end
     theta = thetaStart + (thetaEnd - thetaStart)*t
-    point[1] = center[1] + r*cos(theta*fctr)
-    point[2] = center[2] + r*sin(theta*fctr)
+    point[1] = center[1] + r * cos(theta * fctr)
+    point[2] = center[2] + r * sin(theta * fctr)
 end
 
 
-function endPointsLineCurvePoints(xStart::Array{Float64}, xEnd::Array{Float64}, t::Array{Float64}, points::Array{Float64})
+function ellipseCurvePoints(center::Array{Float64}, x_r::Float64, y_r::Float64,
+                            thetaStart::Float64, thetaEnd::Float64,
+                            rot::Float64, units::AbstractString,
+                            t::Array{Float64}, points::Array{Float64,2})
+    fctr::Float64 = 1.0
+    if units == "degrees"
+        fctr = pi / 180.0
+    end
+
+    for i = 1:length(t)
+        theta = thetaStart + (thetaEnd - thetaStart) * t[i]
+        points[i, 1] = (center[1] + x_r * cos(theta * fctr) * cos(rot * fctr)
+                                  - y_r * sin(theta * fctr) * sin(rot * fctr))
+        points[i, 2] = (center[2] + x_r * cos(theta * fctr) * sin(rot * fctr)
+                                  + y_r * sin(theta * fctr) * cos(rot * fctr))
+    end
+end
+
+
+function ellipseCurvePoint(center::Array{Float64}, x_r::Float64, y_r::Float64,
+                           thetaStart::Float64, thetaEnd::Float64,
+                           rot::Float64, units::AbstractString,
+                           t::Float64, point::Array{Float64})
+    fctr::Float64 = 1.0
+    if units == "degrees"
+        fctr = pi / 180.0
+    end
+    theta = thetaStart + (thetaEnd - thetaStart) * t
+    point[1] = (center[1] + x_r * cos(theta * fctr) * cos(rot * fctr)
+                          - y_r * sin(theta * fctr) * sin(rot * fctr))
+    point[2] = (center[2] + x_r * cos(theta * fctr) * sin(rot * fctr)
+                          + y_r * sin(theta * fctr) * cos(rot * fctr))
+end
+
+
+function endPointsLineCurvePoints(xStart::Array{Float64}, xEnd::Array{Float64},
+                                  t::Array{Float64}, points::Array{Float64})
     for i = 1:length(t)
         points[i,1:2] = xStart[1:2] + t[i]*(xEnd[1:2] - xStart[1:2])
     end
 end
 
 
-function endPointsLineCurvePoint(xStart::Array{Float64}, xEnd::Array{Float64}, t::Float64, point::Array{Float64})
+function endPointsLineCurvePoint(xStart::Array{Float64}, xEnd::Array{Float64},
+                                 t::Float64, point::Array{Float64})
         point[1:2] = xStart[1:2] + t*(xEnd[1:2] - xStart[1:2])
 end
 
@@ -155,6 +193,22 @@ function curvePoints(crvDict::Dict{String,Any}, N::Int)
         end
 
         arcCurvePoints(center,radius,startAngle,endAngle,units,t,x)
+    elseif curveType == "ELLIPTIC_ARC"
+        center     = realArrayForKeyFromDictionary("center",crvDict)
+        xRadius    = realForKeyFromDictionary("xRadius",crvDict)
+        yRadius    = realForKeyFromDictionary("yRadius",crvDict)
+        startAngle = realForKeyFromDictionary("start angle",crvDict)
+        endAngle   = realForKeyFromDictionary("end angle",crvDict)
+        units      = crvDict["units"]
+        rotation   = realForKeyFromDictionary("rotation",crvDict)
+
+        x = zeros(Float64,N+1,2)
+        t = zeros(Float64,N+1)
+        for i = 1:N+1
+            t[i] = (i-1)/N
+        end
+
+        ellipseCurvePoints(center,xRadius,yRadius,startAngle,endAngle,rotation,units,t,x)
     elseif curveType == "SPLINE_CURVE"
         nKnots = intForKeyFromDictionary("nKnots",crvDict)
         splineData = crvDict["SPLINE_DATA"]
@@ -201,6 +255,16 @@ function curvePoint(crvDict::Dict{String,Any}, t::Float64)
         units      = crvDict["units"]
         x = zeros(Float64,3)
         arcCurvePoint(center,radius,startAngle,endAngle,units,t,x)
+    elseif curveType == "ELLIPTIC_ARC"
+        center     = realArrayForKeyFromDictionary("center",crvDict)
+        xRadius    = realForKeyFromDictionary("xRadius",crvDict)
+        yRadius    = realForKeyFromDictionary("yRadius",crvDict)
+        startAngle = realForKeyFromDictionary("start angle",crvDict)
+        endAngle   = realForKeyFromDictionary("end angle",crvDict)
+        units      = crvDict["units"]
+        rotation   = realForKeyFromDictionary("rotation",crvDict)
+        x = zeros(Float64,3)
+        ellipseCurvePoint(center,xRadius,yRadius,startAngle,endAngle,rotation,units,t,x)
     elseif curveType == "SPLINE_CURVE"
         nKnots = intForKeyFromDictionary("nKnots",crvDict)
         splineData = crvDict["SPLINE_DATA"]
@@ -211,7 +275,8 @@ function curvePoint(crvDict::Dict{String,Any}, t::Float64)
 end
 
 
-function curvesMeet(firstCurve::Dict{String,Any}, secondCurve::Dict{String,Any}; tol=100*eps(Float64))
+function curvesMeet(firstCurve::Dict{String,Any}, secondCurve::Dict{String,Any};
+                    tol=100*eps(Float64))
     xFirst  = curvePoint(firstCurve,1.0)
     xSecond = curvePoint(secondCurve,0.0)
     if maximum(abs.(xFirst - xSecond)) < tol

--- a/src/HOHQMesh.jl
+++ b/src/HOHQMesh.jl
@@ -108,7 +108,7 @@ export addCurveToOuterBoundary!,
        getChainIndex,
        getInnerBoundaryChainWithName,
        getInnerBoundaryCurve
-# `ModelAPI.jl` functions specific to boundary curve optimzation
+# `ModelAPI.jl` functions specific to boundary curve optimization
 export getOuterBoundaryOptimizeStatus, setOuterBoundaryOptimizeStatus!,
        getOuterBoundaryTolerance, setOuterBoundaryTolerance!,
        getOuterBoundaryContinuity, setOuterBoundaryContinuity!,

--- a/src/HOHQMesh.jl
+++ b/src/HOHQMesh.jl
@@ -75,6 +75,7 @@ export addBackgroundGrid!, removeBackgroundGrid!,
 export newParametricEquationCurve,
        newEndPointsLineCurve,
        newCircularArcCurve,
+       newEllipticArcCurve,
        newSplineCurve,
        setCurveName!, getCurveName,
        getCurveType,
@@ -88,6 +89,7 @@ export newParametricEquationCurve,
        setArcStartAngle!, getArcStartAngle,
        setArcEndAngle!, getArcEndAngle,
        setArcRadius!, getArcRadius,
+       setArcRotation!, getArcRotation,
        setSplineNKnots!, getSplineNKnots,
        setSplinePoints!, getSplinePoints
 
@@ -106,6 +108,15 @@ export addCurveToOuterBoundary!,
        getChainIndex,
        getInnerBoundaryChainWithName,
        getInnerBoundaryCurve
+# `ModelAPI.jl` functions specific to boundary curve optimzation
+export getOuterBoundaryOptimizeStatus, setOuterBoundaryOptimizeStatus!,
+       getOuterBoundaryTolerance, setOuterBoundaryTolerance!,
+       getOuterBoundaryContinuity, setOuterBoundaryContinuity!,
+       getOuterBoundaryConnect, setOuterBoundaryConnect!,
+       getInnerBoundaryChainOptimizeStatus, setInnerBoundaryChainOptimizeStatus!,
+       getInnerBoundaryChainTolerance, setInnerBoundaryChainTolerance!,
+       getInnerBoundaryChainContinuity, setInnerBoundaryChainContinuity!,
+       getInnerBoundaryChainConnect, setInnerBoundaryChainConnect!
 
 # Functions from `Project.jl`
 export newProject, openProject, saveProject, renameCurve!

--- a/src/Project/CurvesAPI.jl
+++ b/src/Project/CurvesAPI.jl
@@ -49,10 +49,10 @@ end
 
 """
     newCircularArcCurve(name::String, center::Array{Float64},
-        startAngle::Float64, endAngle::Float64,
+        radius::Float64, startAngle::Float64, endAngle::Float64,
         units::String)
 
-Creates and returns a new circular arc curve in the form of a Dictionary
+Creates and returns a new circular arc curve in the form of a Dictionary.
 """
 function newCircularArcCurve(name::String,
                              center::Array{Float64},
@@ -74,6 +74,41 @@ function newCircularArcCurve(name::String,
     enableNotifications()
     enableUndo()
     return arc
+end
+
+
+"""
+    newEllipticArcCurve(name::String, center::Array{Float64},
+                        xRadius::Float64, yRadius::Float64,
+                        startAngle::Float64, endAngle::Float64,
+                        rotation::Float64, units::String)
+
+Creates and returns a new elliptic arc curve in the form of a Dictionary.
+"""
+function newEllipticArcCurve(name::String,
+                             center::Array{Float64},
+                             xRadius::Float64,
+                             yRadius::Float64,
+                             startAngle::Float64,
+                             endAngle::Float64,
+                             rotation::Float64 = 0.0,
+                             units::String = "degrees")
+
+    ellipse = Dict{String,Any}()
+    ellipse["TYPE"] = "ELLIPTIC_ARC"
+    disableNotifications()
+    disableUndo()
+    setCurveName!(ellipse,name)
+    setArcUnits!(ellipse,units)
+    setArcCenter!(ellipse,center)
+    setArcStartAngle!(ellipse,startAngle)
+    setArcEndAngle!(ellipse,endAngle)
+    setArcRadius!(ellipse,xRadius,"xRadius")
+    setArcRadius!(ellipse,yRadius,"yRadius")
+    setArcRotation!(ellipse,rotation)
+    enableNotifications()
+    enableUndo()
+    return ellipse
 end
 
 
@@ -165,7 +200,7 @@ end
     getCurveType(crv::Dic{String,Any})
 
     Get the type of the curve, `END_POINTSLINE_CURVE`, `PARAMETRIC_EQUATION_CURVE`,
-    `SPLINE_CURVE`, or `CIRCULAR_ARC` as a string.
+    `SPLINE_CURVE`, `CIRCULAR_ARC`, or `ELLIPTIC_ARC` as a string.
 """
 function getCurveType(crv::Dict{String,Any})
     return crv["TYPE"]
@@ -273,7 +308,7 @@ end
 
 
 """
-    getStartPoint(crv::Dict{String,Any}, point::Array{Float64})
+    getStartPoint(crv::Dict{String,Any})
 
 Get the start point for a line curve as an array
 """
@@ -305,7 +340,7 @@ end
 
 
 """
-    getEndPoint(crv::Dict{String,Any}, point::Array{Float64})
+    getEndPoint(crv::Dict{String,Any})
 
 Get the end point for a line curve as an array.
 """
@@ -317,7 +352,7 @@ end
 """
     setArcUnits!(crv::Dict{String,Any}, units::String)
 
-Set the units for the start and end angles of a circular arc curve.
+Set the units for the start and end angles of a circular or elliptic arc curve.
 """
 function setArcUnits!(arc::Dict{String,Any}, units::String)
     if units == "degrees" || units == "radians"
@@ -335,7 +370,7 @@ end
 
 
 """
-    getArcUnits(crv::Dict{String,Any}, units::String)
+    getArcUnits(crv::Dict{String,Any})
 
 Get the units for the start and end angles of a circular arc curve.
 """
@@ -347,7 +382,7 @@ end
 """
     setArcCenter!(crv::Dict{String,Any}, point::Array{Float64})
 
-Set the center of a circular arc.
+Set the center of a circular or elliptic arc.
 """
 function setArcCenter!(arc::Dict{String,Any}, point::Array{Float64})
     pStr = "[$(point[1]),$(point[2]),$(point[3])]"
@@ -366,9 +401,9 @@ end
 
 
 """
-    getArcCenter(crv::Dict{String,Any}, point::Array{Float64})
+    getArcCenter(crv::Dict{String,Any})
 
-Get the center of a circular arc as an array
+Get the center of a circular or elliptic arc as an array
 """
 function getArcCenter(arc::Dict{String,Any})
     return realArrayForKeyFromDictionary("center",arc)
@@ -390,7 +425,7 @@ end
 
 
 """
-    getArcStartAngle(arc::Dict{String,Any}, angle::Float64)
+    getArcStartAngle(arc::Dict{String,Any})
 """
 function getArcStartAngle(arc::Dict{String,Any})
     return parse(Float64,arc["start angle"])
@@ -412,7 +447,7 @@ end
 
 
 """
-    getArcEndAngle(arc::Dict{String,Any}, angle::Float64)
+    getArcEndAngle(arc::Dict{String,Any})
 """
 function getArcEndAngle(arc::Dict{String,Any})
     return parse(Float64,arc["end angle"])
@@ -420,10 +455,9 @@ end
 
 
 """
-    setArcRadius!(arc::Dict{String,Any}, radius::Float64)
+    setArcRadius!(arc::Dict{String,Any}, radius::Float64, key::String)
 """
-function setArcRadius!(arc::Dict{String,Any}, radius::Float64)
-    key = "radius"
+function setArcRadius!(arc::Dict{String,Any}, radius::Float64, key::String = "radius")
     if haskey(arc,key)
         oldVal = parse(Float64,arc[key])
         registerWithUndoManager(arc,setArcRadius!, (oldVal,), "Set Arc Radius")
@@ -434,10 +468,32 @@ end
 
 
 """
-    getArcRadius(arc::Dict{String,Any}, radius::Float64)
+    getArcRadius(arc::Dict{String,Any}, key::String = "radius")
 """
-function getArcRadius(arc::Dict{String,Any})
-    return parse(Float64,arc["radius"])
+function getArcRadius(arc::Dict{String,Any}, key::String = "radius")
+    return parse(Float64,arc[key])
+end
+
+
+"""
+    setArcRotation!(arc::Dict{String,Any}, rotation::Float64)
+"""
+function setArcRotation!(arc::Dict{String,Any}, rotation::Float64)
+    key = "rotation"
+    if haskey(arc,key)
+        oldVal = parse(Float64,arc[key])
+        registerWithUndoManager(arc,setArcRotation!, (oldVal,), "Set Arc Rotation")
+    end
+    arc[key] = string(rotation)
+    postNotificationWithName(arc,"CURVE_DID_CHANGE_NOTIFICATION",(nothing,))
+end
+
+
+"""
+    getArcRotation(arc::Dict{String,Any})
+"""
+function getArcRotation(arc::Dict{String,Any})
+    return parse(Float64,arc["rotation"])
 end
 
 

--- a/src/Project/Generics.jl
+++ b/src/Project/Generics.jl
@@ -52,6 +52,31 @@ end
 
 
 """
+    new(name::String,
+        center::Array{Float64},
+        xradius::Float64,
+        yradius::Float64,
+        startAngle::Float64,
+        endAngle::Float64,
+        rotation::Float64,
+        units::String)
+
+Create a new elliptic arc.
+"""
+function new(name::String,
+            center::Array{Float64},
+            xradius::Float64,
+            yradius::Float64,
+            startAngle::Float64,
+            endAngle::Float64,
+            rotation::Float64 = 0.0,
+            units::String = "degrees")
+    return newEllipticArcCurve(name,center,xradius,yradius,
+                               startAngle,endAngle,rotation,units)
+end
+
+
+"""
     new(name::String, dataFile::String)
 
 Create a spline curve from the contents of a data file.

--- a/src/Project/Generics.jl
+++ b/src/Project/Generics.jl
@@ -115,7 +115,7 @@ getCurve(proj::Project, curveName::String, boundaryName::String)
 Get the curve named `curveName` from the inner boundary named `boundaryName`
 """
 function getCurve(proj::Project, curveName::String, boundaryName::String)
-    return  getInnerBoundaryCurve(proj, curveName, boundaryName)
+    return getInnerBoundaryCurve(proj, curveName, boundaryName)
 end
 
 

--- a/src/Project/ModelAPI.jl
+++ b/src/Project/ModelAPI.jl
@@ -144,11 +144,25 @@ function getOuterBoundaryChainList(proj::Project)
         lst = outerBndryDict["LIST"]
         return lst
     else
+        # This is the creation of the CHAIN for the OUTER_BOUNDARY
+        # and here we instantiate the keywords for the boundary
+        # curve optimization defaults.
+        # Default values are: optimization off,
+        #                     tol = 1e-3,
+        #                     continuity = 0
+        #                     connect = empty
+        outerBndryDict["optimize"] = "none"
+        outerBndryDict["tolerance"] = "1.0e-3"
+        outerBndryDict["continuity"] = "0"
+        outerBndryDict["connect"] = "[]"
         lst = Dict{String,Any}[]
         outerBndryDict["LIST"] = lst
         return lst
     end
 end
+
+# TODO: setter, getter functions for the OUTER_BOUNDARY optimization keywords
+
 #
 #  --------------------------------------------------------------------------------------
 #           INNER BOUNDARY FUNCTIONS
@@ -319,6 +333,17 @@ function addInnerBoundaryWithName!(proj::Project,name::String)
     bndryChain["TYPE"] = "CHAIN"
     bndryCurves        = Dict{String,Any}[]
     bndryChain["LIST"] = bndryCurves
+#
+#   Keywords in the chain for the boundary optimization
+#   Default values are: optimization off,
+#                       tol = 1e-3,
+#                       continuity = 0
+#                       connect = empty
+#
+    bndryChain["optimize"] = "none"
+    bndryChain["tolerance"] = "1.0e-3"
+    bndryChain["continuity"] = "0"
+    bndryChain["connect"] = "[]"
 
     innerBoundariesList = getAllInnerBoundaries(proj)
     push!(innerBoundariesList,bndryChain)
@@ -332,6 +357,7 @@ function addInnerBoundaryWithName!(proj::Project,name::String)
     return bndryChain
 end
 
+# TODO: setter, getter functions for the OUTER_BOUNDARY optimization keywords
 
 function getChainIndex(chain::Vector{Dict{String, Any}},name)
     for (i,dict) in enumerate(chain)

--- a/src/Project/ModelAPI.jl
+++ b/src/Project/ModelAPI.jl
@@ -127,12 +127,6 @@ function removeOuterBoundary!(proj::Project)
 end
 
 
-# function addOuterBoundary(proj::Project,obDict::Dict{String,Any})
-#     modelDict = getModelDict(proj)
-#     modelDict["OUTER_BOUNDARY"] = obDict
-# end
-
-
 """
     getOuterBoundaryChainList(proj::Project)
 
@@ -152,7 +146,7 @@ function getOuterBoundaryChainList(proj::Project)
         #                     continuity = 0
         #                     connect = empty
         outerBndryDict["optimize"] = "none"
-        outerBndryDict["tolerance"] = "1.0e-3"
+        outerBndryDict["tolerance"] = "1e-3"
         outerBndryDict["continuity"] = "0"
         outerBndryDict["connect"] = "[]"
         lst = Dict{String,Any}[]
@@ -161,7 +155,124 @@ function getOuterBoundaryChainList(proj::Project)
     end
 end
 
-# TODO: setter, getter functions for the OUTER_BOUNDARY optimization keywords
+
+"""
+    getOuterBoundaryOptimizeStatus(proj::Project)
+
+Returns the current type for the boundary curve optimization
+for the outer boundary chain.
+"""
+function getOuterBoundaryOptimizeStatus(proj::Project)
+    outerBndryDict = getDictInModelDictNamed(proj,"OUTER_BOUNDARY")
+    return outerBndryDict["optimize"]
+end
+
+
+"""
+    setOuterBoundaryOptimizeStatus!(proj:Project, type::String)
+
+Adjust the type for the boundary curve optimization for the outer boundary chain.
+Available types are `none`, `L2Norm`, or `H1Norm`.
+"""
+function setOuterBoundaryOptimizeStatus!(proj::Project, type::String)
+    if !in(type, optimizeTypes)
+        @warn "Acceptable optimization types are `none`, `L2Norm`, or `H1Norm`. Try again."
+        return
+    end
+    outerBndryDict = getDictInModelDictNamed(proj,"OUTER_BOUNDARY")
+    outerBndryDict["optimize"] = type
+end
+
+
+"""
+    getOuterBoundaryTolerance(proj::Project)
+
+Returns the current tolerance for the boundary optimization of the outer boundary chain.
+"""
+function getOuterBoundaryTolerance(proj::Project)
+    outerBndryDict = getDictInModelDictNamed(proj, "OUTER_BOUNDARY")
+    return parse(Float64, outerBndryDict["tolerance"])
+end
+
+
+"""
+    setOuterBoundaryTolerance!(proj::Project, tolerance::Float64)
+
+Sets the tolerance for the boundary optimization of the outer boundary chain.
+"""
+function setOuterBoundaryTolerance!(proj::Project, tolerance::Float64)
+    if tolerance < 0
+        @warn "The boundary tolerance must be non-negative. Try again."
+        return
+    elseif tolerance < 1e-5
+        @warn "Setting a low tolerance may not be achievable or the mesh generation may take an inordinate amount of time. Think about how accurate of a mesh is needed before choosing a low tolerance like $tolerance."
+    end
+
+    outerBndryDict = getDictInModelDictNamed(proj, "OUTER_BOUNDARY")
+    outerBndryDict["tolerance"] = string(tolerance)
+end
+
+
+"""
+    getOuterBoundaryContinuity(proj::Project)
+
+Returns the current continuity (number of continuous derivatives) for
+the boundary optimization of the outer boundary chain.
+"""
+function getOuterBoundaryContinuity(proj::Project)
+    outerBndryDict = getDictInModelDictNamed(proj, "OUTER_BOUNDARY")
+    return parse(Int, outerBndryDict["continuity"])
+end
+
+
+"""
+    setOuterBoundaryContinuity!(proj::Project, continuity::Int)
+
+Sets the continuity (number of continuous derivatives) for
+the boundary optimization of the outer boundary chain.
+"""
+function setOuterBoundaryContinuity!(proj::Project, continuity::Int)
+    if continuity < 0
+        @warn "The continuity must be non-negative. Try again."
+        return
+    elseif continuity > 2
+        @warn "Higher continuity constraints can lead to ill-conditioned systems in the optimization procedure."
+    end
+
+    outerBndryDict = getDictInModelDictNamed(proj, "OUTER_BOUNDARY")
+    outerBndryDict["continuity"] = string(continuity)
+end
+
+
+"""
+    getOuterBoundaryConnect(proj::Project)
+
+Returns the current connect setting for the boundary optimization of the outer boundary chain.
+"""
+function getOuterBoundaryConnect(proj::Project)
+    outerBndryDict = getDictInModelDictNamed(proj, "OUTER_BOUNDARY")
+    return outerBndryDict["connect"]
+end
+
+
+"""
+    setOuterBoundaryConnect!(proj::Project, connect::String)
+
+Sets the connect setting for the boundary optimization of the outer boundary chain.
+
+By default, boundary curve optimization is done curve by curve within the chain
+with an "empty" `connect = "[]"` key,
+as usually there will be discontinuities (e.g. corners) between the curves.
+If it is desired to define a more global approximation across multiple curves
+update the `connect` key.
+For example, if the chain has four segments then `connect = "2-3"` requests
+that optimization occurs across curve segments two and three in the list,
+where as curves 1 and 4 are optimized individually.
+"""
+function setOuterBoundaryConnect!(proj::Project, connect::String)
+    outerBndryDict = getDictInModelDictNamed(proj, "OUTER_BOUNDARY")
+    outerBndryDict["connect"] = connect
+end
 
 #
 #  --------------------------------------------------------------------------------------
@@ -341,7 +452,7 @@ function addInnerBoundaryWithName!(proj::Project,name::String)
 #                       connect = empty
 #
     bndryChain["optimize"] = "none"
-    bndryChain["tolerance"] = "1.0e-3"
+    bndryChain["tolerance"] = "1e-3"
     bndryChain["continuity"] = "0"
     bndryChain["connect"] = "[]"
 
@@ -357,7 +468,6 @@ function addInnerBoundaryWithName!(proj::Project,name::String)
     return bndryChain
 end
 
-# TODO: setter, getter functions for the OUTER_BOUNDARY optimization keywords
 
 function getChainIndex(chain::Vector{Dict{String, Any}},name)
     for (i,dict) in enumerate(chain)
@@ -367,6 +477,130 @@ function getChainIndex(chain::Vector{Dict{String, Any}},name)
     end
     return 0
 end
+
+
+"""
+    getInnerBoundaryChainOptimizeStatus(proj::Project, chainName::String)
+
+Returns the current type of the boundary curve optimization
+of an inner boundary CHAIN with `chainName`.
+"""
+function getInnerBoundaryChainOptimizeStatus(proj::Project, chainName::String)
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    return innerBndryDict["optimize"]
+end
+
+
+"""
+    setInnerBoundaryChainOptimizeStatus!(proj:Project, chainName::String, type::String)
+
+Adjust the type for the boundary curve optimization of an inner boundary CHAIN with `chainName`.
+Available types are `none`, `L2Norm`, or `H1Norm`.
+"""
+function setInnerBoundaryChainOptimizeStatus!(proj::Project, chainName::String, type::String)
+    if !in(type, optimizeTypes)
+        @warn "Acceptable optimization types are `none`, `L2Norm`, or `H1Norm`. Try again."
+        return
+    end
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    innerBndryDict["optimize"] = type
+end
+
+
+"""
+    getInnerBoundaryChainTolerance(proj::Project, chainName::String)
+
+Returns the current tolerance for the boundary curve optimization
+of an inner boundary CHAIN with `chainName`.
+"""
+function getInnerBoundaryChainTolerance(proj::Project, chainName::String)
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    return parse(Float64, innerBndryDict["tolerance"])
+end
+
+
+"""
+    setInnerBoundaryChainTolerance!(proj::Project, chainName::String, tolerance::Float64)
+
+Sets the tolerance for the boundary curve optimization
+of an inner boundary CHAIN with `chainName`.
+"""
+function setInnerBoundaryChainTolerance!(proj::Project, chainName::String, tolerance::Float64)
+    if tolerance < 0
+        @warn "The boundary tolerance must be non-negative. Try again."
+        return
+    elseif tolerance < 1e-5
+        @warn "Setting a low tolerance may not be achievable or the mesh generation may take an inordinate amount of time. Think about how accurate of a mesh is needed before choosing a low tolerance like $tolerance."
+    end
+
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    innerBndryDict["tolerance"] = string(tolerance)
+end
+
+
+"""
+    getInnerBoundaryChainContinuity(proj::Project, chainName::String)
+
+Returns the current continuity (number of continuous derivatives) for
+the boundary curve optimization of an inner boundary CHAIN with `chainName`.
+"""
+function getInnerBoundaryChainContinuity(proj::Project, chainName::String)
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    return parse(Int, innerBndryDict["continuity"])
+end
+
+
+"""
+    setInnerBoundaryChainContinuity!(proj::Project, chainName::String, continuity::Int)
+
+Sets the continuity (number of continuous derivatives) for
+the boundary curve optimization of an inner boundary CHAIN with `chainName`.
+"""
+function setInnerBoundaryChainContinuity!(proj::Project, chainName::String, continuity::Int)
+    if continuity < 0
+        @warn "The continuity must be non-negative. Try again."
+        return
+    elseif continuity > 2
+        @warn "Higher continuity constraints can lead to ill-conditioned systems in the optimization procedure."
+    end
+
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    innerBndryDict["continuity"] = string(continuity)
+end
+
+
+"""
+    getInnerBoundaryChainConnect(proj::Project, chainName::String)
+
+Returns the current connect setting for the boundary curve optimization
+of an inner boundary CHAIN with `chainName`.
+"""
+function getInnerBoundaryChainConnect(proj::Project, chainName::String)
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    return innerBndryDict["connect"]
+end
+
+
+"""
+    setInnerBoundaryChainConnect!(proj::Project, chainName::String, connect::String)
+
+Sets the connect setting for the boundary curve optimization
+of an inner boundary CHAIN with `chainName`.
+
+By default, boundary curve optimization is done curve by curve within the chain
+with an "empty" `connect = "[]"` key,
+as usually there will be discontinuities (e.g. corners) between the curves.
+If it is desired to define a more global approximation across multiple curves
+update the `connect` key.
+For example, if the chain has four segments then `connect = "2-3"` requests
+that optimization occurs across curve segments two and three in the list,
+where as curves 1 and 4 are optimized individually.
+"""
+function setInnerBoundaryChainConnect!(proj::Project, chainName::String, connect::String)
+    _, innerBndryDict = getInnerBoundaryChainWithName(proj, chainName)
+    innerBndryDict["connect"] = connect
+end
+
 
 """
     getAllInnerBoundaries(proj::Project)
@@ -415,9 +649,8 @@ function getInnerBoundaryChainWithName(proj::Project, name::String)
     chain = addInnerBoundaryWithName!(proj,name)
     return l+1, chain
 end
-"""
 
-"""
+
 function getInnerBoundaryCurve(proj::Project, curveName::String, boundaryName::String)
     i, chain = getInnerBoundaryChainWithName(proj, boundaryName)
     lst = chain["LIST"]

--- a/src/Project/Project.jl
+++ b/src/Project/Project.jl
@@ -34,6 +34,7 @@ const defaultPlotPts  = 200
 const meshFileFormats = Set(["ISM", "ISM-V2", "ABAQUS"])
 const plotFileFormats = Set(["sem", "skeleton"])
 const smootherTypes   = Set(["LinearSpring", "LinearAndCrossbarSpring"])
+const optimizeTypes   = Set(["none", "L2Norm", "H1Norm"])
 const statusValues    = Set(["ON", "OFF"])
 const refinementTypes = Set(["smooth", "sharp"])
 

--- a/src/Project/SmootherAPI.jl
+++ b/src/Project/SmootherAPI.jl
@@ -7,7 +7,7 @@ Type is either `LinearSpring` or `LinearAndCrossbarSpring`
 """
 function addSpringSmoother!(proj::Project,status::String = "ON",
                             type::String = "LinearAndCrossbarSpring",
-                            nIterations::Int = 25)
+                            nIterations::Int = 15)
     if !in(status,statusValues)
         @warn "Acceptable smoother status are: `ON` or `OFF`. Try again."
         return
@@ -49,7 +49,7 @@ end
 
 
 """
-    setSmoothingType!(proj:Project, status::String)
+    setSmoothingType!(proj:Project, type::String)
 
 Type is either `LinearSpring` or `LinearAndCrossbarSpring`
 """
@@ -81,7 +81,7 @@ Set the number of iterations to smooth the mesh.
 """
 function setSmoothingIterations!(proj::Project, iterations::Int)
     smDict = getDictInControlDictNamed(proj,"SPRING_SMOOTHER")
-    smDict["number of iterations"] = iterations
+    smDict["number of iterations"] = string(iterations)
 end
 
 
@@ -92,7 +92,7 @@ Get the number of iterations to smooth the mesh.
 """
 function getSmoothingIterations(proj::Project)
     smDict = getDictInControlDictNamed(proj,"SPRING_SMOOTHER")
-    return smDict["number of iterations"]
+    return parse(Int, smDict["number of iterations"])
 end
 
 

--- a/test/test_background_grid.jl
+++ b/test/test_background_grid.jl
@@ -70,7 +70,7 @@ using Test
     removeBackgroundGrid!(p)
     @test HOHQMesh.hasBackgroundGrid(p) == false
 #
-#   There are no longer any background grid. Delete the notification center piece as well.
+#   There is no longer any background grid. Delete the notification center piece as well.
 #   Note that the notification center is global and can have multiple observers. So we test
 #   this notification center removal before other observers, e.g. other projects in the
 #   testing runs, are created that will add in the background grid again.

--- a/test/test_curve.jl
+++ b/test/test_curve.jl
@@ -16,6 +16,14 @@ Functions: @ = tested
                              startAngle::Float64,
                              endAngle::Float64,
                              units::String = "degrees")
+    @(as new)   newEllipticArcCurve(name::String,
+                             center::Array{Float64},
+                             xradius::Float64,
+                             yradius::Float64,
+                             startAngle::Float64,
+                             endAngle::Float64,
+                             rotation::Float64,
+                             units::String = "degrees")
     @   newSplineCurve(name::String, nKnots::Int, data::Matrix{Float64})
     newSplineCurve(name::String, dataFile::String)
     @   setCurveName!(crv::Dict{String,Any}, name::String)
@@ -48,6 +56,8 @@ Functions: @ = tested
     @   getSplineNKnots(spline::Dict{String,Any})
     @   setSplinePoints!(spline::Dict{String,Any},points::Matrix{Float64})
     @   getSplinePoints(spline::Dict{String,Any})
+    @   setArcRotation!(arc::Dict{String,Any}, rotation::Float64)
+    @   getArcRotation(arc::Dict{String,Any})
 =#
 using HOHQMesh
 using Test
@@ -147,7 +157,7 @@ using Test
         @test isapprox(pts[2,:],[0.0,2.0])
         @test isapprox(pts[3,:],[-2.0,0.0])
 
-        # Purposly trigger warning with invalid units
+        # Purposely trigger warning with invalid units
         @test_logs (:warn, "Units must either be `degrees` or `radians`. Try setting `units` again.") setArcUnits!(crv,"Rankine")
 
         setArcUnits!(crv,"radians")
@@ -170,6 +180,43 @@ using Test
         @test getArcEndAngle(crv) == 270.0
         setArcRadius!(crv, 1.5)
         @test getArcRadius(crv) == 1.5
+    end
+
+    @testset "EllipticArc Tests" begin
+        center      = [0.0,0.0,0.0]
+        xradius     = 1.0
+        yradius     = 2.0
+        startAngleD = 0.0
+        endAngleD   = 180.0
+        rotation    = 0.0
+        name        = "EllipticArcCurve"
+
+        crv = new(name, center, xradius, yradius, startAngleD, endAngleD, rotation, "degrees")
+
+        @test typeof(crv)                  == Dict{String,Any}
+        @test getCurveType(crv)            == "ELLIPTIC_ARC"
+        @test getCurveName(crv)            == name
+        @test getArcCenter(crv)            == center
+        @test getArcRadius(crv, "xRadius") == xradius
+        @test getArcRadius(crv, "yRadius") == yradius
+        @test getArcStartAngle(crv)        == startAngleD
+        @test getArcRotation(crv)          == rotation
+        @test getArcUnits(crv)             == "degrees"
+
+        pt = HOHQMesh.curvePoint(crv, 0.5)
+        @test isapprox(pt,[0.0,2.0,0.0])
+
+        pts = HOHQMesh.curvePoints(crv,2)
+        @test isapprox(pts[1,:],[1.0,0.0])
+        @test isapprox(pts[2,:],[0.0,2.0])
+        @test isapprox(pts[3,:],[-1.0,0.0])
+
+        setArcRotation!(crv, -45.0)
+        @test getArcRotation(crv) == -45.0
+        undo()
+        @test getArcRotation(crv) == 0.0
+        redo()
+        @test getArcRotation(crv) == -45.0
     end
 
     @testset "Spline Tests" begin

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -255,6 +255,12 @@ end
         setInnerBoundaryChainOptimizeStatus!(p, chainName, "invalid")
     end
 
+    setInnerBoundaryChainOptimizeStatus!(p, chainName, "L2Norm")
+    @test getInnerBoundaryChainOptimizeStatus(p, chainName) == "L2Norm"
+
+    setInnerBoundaryChainOptimizeStatus!(p, chainName, "H1Norm")
+    @test getInnerBoundaryChainOptimizeStatus(p, chainName) == "H1Norm"
+
     # Tolerance keyword functions
 
     @test getInnerBoundaryChainTolerance(p, chainName) == 1.0e-3

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -160,4 +160,144 @@ using Test
 
 end
 
+# Tests for getter / setter functions on the OUTER_BOUNDARY
+@testset "Outer Boundary optimization getters/setters" begin
+    projectName = "TestProject"
+    projectPath = "out"
+
+    p = newProject(projectName, projectPath)
+
+    ell = new("Ellipse", [0.0, -3.0, 0.0], 0.8, 0.35, 0.0, 360.0, -47.0, "degrees")
+    addCurveToOuterBoundary!(p, ell)
+
+    @test getOuterBoundaryOptimizeStatus(p) == "none"
+
+    @test_logs (:warn, "Acceptable optimization types are `none`, `L2Norm`, or `H1Norm`. Try again.") begin
+        setOuterBoundaryOptimizeStatus!(p, "invalid")
+    end
+
+    # Invalid value should not change the current value
+    @test getOuterBoundaryOptimizeStatus(p) == "none"
+
+    setOuterBoundaryOptimizeStatus!(p, "L2Norm")
+    @test getOuterBoundaryOptimizeStatus(p) == "L2Norm"
+
+    setOuterBoundaryOptimizeStatus!(p, "H1Norm")
+    @test getOuterBoundaryOptimizeStatus(p) == "H1Norm"
+
+    # Tolerance keyword functions
+
+    @test getOuterBoundaryTolerance(p) == 1.0e-3
+
+    # Low tolerance: warning should be generated, but value
+    # should still be set
+    @test_logs (:warn, "Setting a low tolerance may not be achievable or the mesh generation may take an inordinate amount of time. Think about how accurate of a mesh is needed before choosing a low tolerance like 1.0e-6.") begin
+        setOuterBoundaryTolerance!(p, 1.0e-6)
+    end
+    @test getOuterBoundaryTolerance(p) == 1.0e-6
+
+    # Negative tolerance: warning and value should NOT change
+    oldTolerance = getOuterBoundaryTolerance(p)
+
+    @test_logs (:warn, "The boundary tolerance must be non-negative. Try again.") begin
+        setOuterBoundaryTolerance!(p, -1.0)
+    end
+
+    @test getOuterBoundaryTolerance(p) == oldTolerance
+
+    # Continuity keyword functions
+
+    @test getOuterBoundaryContinuity(p) == 0
+
+    setOuterBoundaryContinuity!(p, 2)
+    @test getOuterBoundaryContinuity(p) == 2
+
+    # > 2 generates warning but value is still set
+    @test_logs (:warn, "Higher continuity constraints can lead to ill-conditioned systems in the optimization procedure.") begin
+        setOuterBoundaryContinuity!(p, 3)
+    end
+    @test getOuterBoundaryContinuity(p) == 3
+
+    # Negative continuity generates warning and should not change value
+    oldContinuity = getOuterBoundaryContinuity(p)
+
+    @test_logs (:warn, "The continuity must be non-negative. Try again.") begin
+        setOuterBoundaryContinuity!(p, -1)
+    end
+
+    @test getOuterBoundaryContinuity(p) == oldContinuity
+
+    # Connect keyword functions
+
+    @test getOuterBoundaryConnect(p) == "[]"
+
+    setOuterBoundaryConnect!(p, "2-3, 5-7")
+    @test getOuterBoundaryConnect(p) == "2-3, 5-7"
+end
+
+# Tests for getter / setter functions on a CHAIN of INNER_BOUNDARIES
+@testset "Inner Boundary Chain getters/setters" begin
+
+    chainName = "IceCreamCone"
+    p = newProject("innerTest", "out")
+
+    cone1    = newEndPointsLineCurve("cone1", [0.0, -3.0, 0.0], [1.0, 0.0, 0.0])
+    iceCream = newCircularArcCurve("iceCream", [0.0, 0.0, 0.0], 1.0, 0.0, 180.0, "degrees")
+    cone2    = newEndPointsLineCurve("cone2", [-1.0, 0.0, 0.0], [0.0, -3.0, 0.0])
+
+    addCurveToInnerBoundary!(p, cone1, "IceCreamCone")
+    addCurveToInnerBoundary!(p, iceCream, "IceCreamCone")
+    addCurveToInnerBoundary!(p, cone2, "IceCreamCone")
+
+    @test getInnerBoundaryChainOptimizeStatus(p, chainName) == "none"
+
+    @test_logs (:warn, "Acceptable optimization types are `none`, `L2Norm`, or `H1Norm`. Try again.") begin
+        setInnerBoundaryChainOptimizeStatus!(p, chainName, "invalid")
+    end
+
+    # Tolerance keyword functions
+
+    @test getInnerBoundaryChainTolerance(p, chainName) == 1.0e-3
+
+    @test_logs (:warn, "Setting a low tolerance may not be achievable or the mesh generation may take an inordinate amount of time. Think about how accurate of a mesh is needed before choosing a low tolerance like 1.0e-6.") begin
+        setInnerBoundaryChainTolerance!(p, chainName, 1.0e-6)
+    end
+    @test getInnerBoundaryChainTolerance(p, chainName) == 1.0e-6
+
+    oldTolerance = getInnerBoundaryChainTolerance(p, chainName)
+
+    @test_logs (:warn, "The boundary tolerance must be non-negative. Try again.") begin
+        setInnerBoundaryChainTolerance!(p, chainName, -1.0)
+    end
+
+    @test getInnerBoundaryChainTolerance(p, chainName) == oldTolerance
+
+    # Continuity keyword functions
+
+    @test getInnerBoundaryChainContinuity(p, chainName) == 0
+
+    setInnerBoundaryChainContinuity!(p, chainName, 2)
+    @test getInnerBoundaryChainContinuity(p, chainName) == 2
+
+    @test_logs (:warn, "Higher continuity constraints can lead to ill-conditioned systems in the optimization procedure.") begin
+        setInnerBoundaryChainContinuity!(p, chainName, 3)
+    end
+    @test getInnerBoundaryChainContinuity(p, chainName) == 3
+
+    oldContinuity = getInnerBoundaryChainContinuity(p, chainName)
+
+    @test_logs (:warn, "The continuity must be non-negative. Try again.") begin
+        setInnerBoundaryChainContinuity!(p, chainName, -1)
+    end
+
+    @test getInnerBoundaryChainContinuity(p, chainName) == oldContinuity
+
+    # Connect keyword functions
+
+    @test getInnerBoundaryChainConnect(p, chainName) == "[]"
+
+    setInnerBoundaryChainConnect!(p, chainName, "2-3, 5-7")
+    @test getInnerBoundaryChainConnect(p, chainName) == "2-3, 5-7"
+end
+
 end # module

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -107,7 +107,7 @@ using CairoMakie
     # Destroy the mesh and reset the background grid
     @test_nowarn remove_mesh!(p_visu)
 
-    # Add a final inner boundary that contains multiple links in the chain
+    # Add a third inner boundary that contains multiple links in the chain
     edge1 = newEndPointsLineCurve("edge1", [-2.3, -1.0, 0.0], [-1.7, -1.0, 0.0])
     edge2 = newEndPointsLineCurve("edge2", [-1.7, -1.0, 0.0], [-2.0, -0.4, 0.0])
     edge3 = newEndPointsLineCurve("edge3", [-2.0, -0.4, 0.0], [-2.3, -1.0, 0.0])
@@ -115,11 +115,15 @@ using CairoMakie
     add!(p_visu, edge2, "inner3")
     add!(p_visu, edge3, "inner3")
 
+    # Add a final inner boundary that is an ellipse
+    ell = new("Ellipse", [0.0, -3.0, 0.0], 0.8, 0.35, 0.0, 360.0, -47.0, "degrees")
+    add!(p_visu, ell, "inner4")
+
     # Create a refinement center and add it with the generic method
     cent = newRefinementCenter("Center1", "smooth", [-1.25, -3.0, 0.0], 0.2, 1.0)
     add!(p_visu, cent)
 
-    # Set file format to ABAQUS (to exericise plotting routine)
+    # Set file format to ABAQUS (to exercise plotting routine)
     setMeshFileFormat!(p_visu, "ABAQUS")
     meshFileFormat = getMeshFileFormat(p_visu)
     setFileNames!(p_visu, meshFileFormat)
@@ -143,13 +147,13 @@ using CairoMakie
     @test_throws ErrorException remove!(p_visu, "big_spline", "inner2")
     #  (3) Give the correct combination and remove the inner boundary
     remove!(p_visu, "big_spline", "inner1")
-    @test length(p_visu.innerBoundaryNames) == 2
+    @test length(p_visu.innerBoundaryNames) == 3
 
     # Do the rest of the inner boundary removals correctly.
     remove!(p_visu, "small_spline", "inner2")
-    @test length(p_visu.innerBoundaryNames) == 1
-    undo()
     @test length(p_visu.innerBoundaryNames) == 2
+    undo()
+    @test length(p_visu.innerBoundaryNames) == 3
     redo()
 
     # Remove a single part of the chain with multiple curves


### PR DESCRIPTION
This adds the necessary keywords and setter/getter functions for the boundary optimzation procedure in HOHQMesh. The optimization is turned off by default. There is also some documentation of its use. My plan is to add a tutorial of how to use it in a different PR.

This also adds the new curve type `ELLIPTIC_ARC` with necessary docstrings and tests.